### PR TITLE
Add function get_line_from_s_interval

### DIFF
--- a/modules/geometry/line.hpp
+++ b/modules/geometry/line.hpp
@@ -60,7 +60,7 @@ class Line_t : public Shape<bg::model::linestring<T>, T> {
   void reverse() {
     boost::geometry::reverse(Shape<bg::model::linestring<T>, T>::obj_);
   }
-  
+
   void ConcatenateLinestring(const Line_t &other_line) {
     using boost::geometry::append;
     // Get first and last point
@@ -222,7 +222,7 @@ inline Point2d get_normal_at_s(Line l, float s) {
 }
 
 
-inline Line line_from_s_interval(Line line, float begin, float end) {
+inline Line get_line_from_s_interval(Line line, float begin, float end) {
   Line new_line;
   new_line.add_point(get_point_at_s(line, begin));
   std::vector<Point2d> points = line.get_points_in_s_interval(begin, end);
@@ -376,10 +376,10 @@ inline Line ComputeCenterLine(const Line& outer_line_,
 template <typename T>
 std::pair<T, T> merge_bounding_boxes(std::pair<T, T> bb1, std::pair<T, T> bb2) {
   Line_t<T> line; // just use a line and add all points
-  line.add_point(bb1.first); 
+  line.add_point(bb1.first);
   line.add_point(bb1.second);
   line.add_point(bb2.first);
-  line.add_point(bb2.second);    
+  line.add_point(bb2.second);
   return line.bounding_box();
 }
 

--- a/modules/geometry/line.hpp
+++ b/modules/geometry/line.hpp
@@ -50,7 +50,7 @@ class Line_t : public Shape<bg::model::linestring<T>, T> {
   std::vector<T> get_points_in_s_interval(float begin, float end) const {
     std::vector<T> points;
     uint begin_idx = std::lower_bound(s_.begin(), s_.end(), begin) - s_.begin();
-    uint end_idx = std::lower_bound(s_.begin(), s_.end(), end) - s_.begin();
+    uint end_idx = std::upper_bound(s_.begin(), s_.end(), end) - s_.begin();
     std::copy(Shape<bg::model::linestring<T>, T>::obj_.begin() + begin_idx,
               Shape<bg::model::linestring<T>, T>::obj_.begin() + end_idx,
               std::back_inserter(points));

--- a/modules/geometry/tests/geometry_test.cc
+++ b/modules/geometry/tests/geometry_test.cc
@@ -531,6 +531,31 @@ TEST(line, get_s_at_pt_1) {
   EXPECT_TRUE(Point2d(0.0, 2.5) == p5);
 }
 
+TEST(line, get_line_from_s_interval) {
+  using namespace std;
+  using namespace modules::geometry;
+
+  Point2d point_1(0.0, 1.0);
+  Point2d point_2(0.0, 2.0);
+  Point2d point_3(0.0, 3.0);
+
+  Line_t<Point2d> line;
+
+  line.add_point(point_1);
+  line.add_point(point_2);
+  line.add_point(point_3);
+
+  Line_t<Point2d> line_segment = get_line_from_s_interval(line, 0.5, 1.5);
+
+  Point2d p1 = get_point_at_s(line_segment, 0.0);
+  Point2d p2 = get_point_at_s(line_segment, 0.5);
+  Point2d p3 = get_point_at_s(line_segment, 1.0);
+
+  EXPECT_TRUE(Point2d(0.0, 1.5) == p1);
+  EXPECT_TRUE(point_2 == p2);
+  EXPECT_TRUE(Point2d(0.0, 2.5) == p3);
+}
+
 TEST(line, get_nearest_point_1) {
   using namespace std;
   using namespace modules::geometry;

--- a/modules/geometry/tests/geometry_test.cc
+++ b/modules/geometry/tests/geometry_test.cc
@@ -555,6 +555,22 @@ TEST(line, get_line_from_s_interval) {
   EXPECT_TRUE(point_2 == p2);
   EXPECT_TRUE(Point2d(0.0, 2.5) == p3);
 }
+TEST(line, get_line_from_s_interval_entire_line) {
+  using namespace modules::geometry;
+
+  Point2d point_1(0.0, 0.0);
+  Point2d point_2(0.0, 2.0);
+
+  Line_t<Point2d> line;
+
+  line.add_point(point_1);
+  line.add_point(point_2);
+
+  Line_t<Point2d> line_segment = get_line_from_s_interval(line, 0.0, 2.0);
+
+  EXPECT_TRUE(Point2d(0.0, 0.0) == point_1);
+  EXPECT_TRUE(Point2d(0.0, 2.0) == point_2);
+}
 
 TEST(line, get_nearest_point_1) {
   using namespace std;


### PR DESCRIPTION
Add the function get_line_from_s_interval which
+ takes a `Line line` and two `float`'s `begin` and `end` signifying the beginning and end of an interval
+ returns a new `Line` containing all points on the `line` in the closed s-interval `[begin,end]`

A test for the new function is included.

@klemense1 