### PR TITLE
Geometry: amend memory leak by replace ptr* with shared_ptr

### DIFF
--- a/modules/geometry/polygon.hpp
+++ b/modules/geometry/polygon.hpp
@@ -19,7 +19,8 @@ namespace geometry {
 
 //! templated polygon class with a boost polygon as a member function
 template <typename T>
-struct Polygon_t : public Shape<bg::model::polygon<T>, T> {
+class Polygon_t : public Shape<bg::model::polygon<T>, T> {
+ public:
   Polygon_t();
   Polygon_t(const Pose &center, const std::vector<T> points);
   Polygon_t(const Pose &center, const Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic> &points);
@@ -27,7 +28,10 @@ struct Polygon_t : public Shape<bg::model::polygon<T>, T> {
 
   virtual Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic> toArray() const;
 
-  virtual Shape<bg::model::polygon<T>, T> *Clone() const;
+  virtual std::shared_ptr<Shape<bg::model::polygon<T>, T>> Clone() const;
+  inline std::shared_ptr<Polygon_t<T>> rotate(const float &theta) const;
+  inline std::shared_ptr<Polygon_t<T>> translate(const Vec2d &vec) const;
+  inline std::shared_ptr<Polygon_t<T>> transform(const Pose &pose) const;
 
   void UpdateDistancesToCenter();
 
@@ -97,10 +101,24 @@ void Polygon_t<T>::UpdateDistancesToCenter() {
     right_dist_ = std::abs(bg::get<bg::max_corner, 1>(box) - center_y);
 }
 
+template <typename T>
+inline std::shared_ptr<Shape<bg::model::polygon<T>, T>> Polygon_t<T>::Clone() const {
+  return std::shared_ptr<Shape<bg::model::polygon<T>, T>>(dynamic_cast<Shape<bg::model::polygon<T>, T>*>(new Polygon_t<T>(*this)));
+}
 
 template <typename T>
-inline Shape<bg::model::polygon<T>, T> *Polygon_t<T>::Clone() const {
-  return new Polygon_t<T>(*this);
+inline std::shared_ptr<Polygon_t<T>> Polygon_t<T>::rotate(const float &theta) const {
+  return std::shared_ptr<Polygon_t<T>>(dynamic_cast<Polygon_t<T>*>(Shape<bg::model::polygon<T>, T>::rotate(theta).get()));
+}
+
+template <typename T>
+inline std::shared_ptr<Polygon_t<T>> Polygon_t<T>::translate(const Vec2d &vec) const {
+  return std::shared_ptr<Polygon_t<T>>(dynamic_cast<Polygon_t<T>*>(Shape<bg::model::polygon<T>, T>::translate(vec).get()));
+}
+
+template <typename T>
+inline std::shared_ptr<Polygon_t<T>> Polygon_t<T>::transform(const Pose &pose) const {
+  return std::shared_ptr<Polygon_t<T>>(dynamic_cast<Polygon_t<T>*>(Shape<bg::model::polygon<T>, T>::transform(pose).get()));
 }
 
 //! for better usage simple float defines

--- a/modules/geometry/tests/geometry_test.cc
+++ b/modules/geometry/tests/geometry_test.cc
@@ -141,7 +141,7 @@ TEST(geometry, polygon) {
 
   EXPECT_TRUE(p.Valid());
 
-  Polygon *p2 = dynamic_cast<Polygon *>(p.rotate(3.14 / 2));
+  auto p2 = p.rotate(3.14 / 2);
 }
 
 TEST(geometry, standard_shapes) {
@@ -437,8 +437,8 @@ TEST(collision, carshape1) {
   namespace bg = boost::geometry;
 
   Polygon outline = CarLimousine();
-  Polygon *car1 = dynamic_cast<Polygon *>(outline.transform(Pose(0, 0, 0)));
-  Polygon *car2 = dynamic_cast<Polygon *>(outline.transform(Pose(10, 10, 0)));
+  auto car1 = outline.transform(Pose(0, 0, 0));
+  auto car2 = outline.transform(Pose(10, 10, 0));
 
   EXPECT_FALSE(Collide(*car1, *car2));
 }
@@ -451,8 +451,8 @@ TEST(collision, carshape2) {
   namespace bg = boost::geometry;
 
   Polygon outline = CarLimousine();
-  Polygon *car1 = dynamic_cast<Polygon *>(outline.transform(Pose(0, 0, 0)));
-  Polygon *car2 = dynamic_cast<Polygon *>(outline.transform(Pose(1, 0, 3.14)));
+  auto car1 = outline.transform(Pose(0, 0, 0));
+  auto car2 = outline.transform(Pose(1, 0, 3.14));
 
   EXPECT_TRUE(Collide(*car1, *car2));
 }

--- a/modules/world/objects/agent.cpp
+++ b/modules/world/objects/agent.cpp
@@ -105,7 +105,7 @@ geometry::Polygon Agent::GetPolygonFromState(const State& state) const {
 
   Pose agent_pose(state(StateDefinition::X_POSITION), state(StateDefinition::Y_POSITION), state(StateDefinition::THETA_POSITION));
 
-  std::shared_ptr<geometry::Polygon> polygon(dynamic_cast<Polygon *>(this->get_shape().transform(agent_pose)));
+  std::shared_ptr<geometry::Polygon> polygon(this->get_shape().transform(agent_pose));
 
   return *polygon;
 }

--- a/python/geometry/geometry.cpp
+++ b/python/geometry/geometry.cpp
@@ -49,16 +49,16 @@ void python_geometry(py::module m) {
         "Returns euclidean distance between modules::geometry::Line2d and modules::geometry::Point2d.");
 
   m.def("distance", py::overload_cast<const modules::geometry::Line &, const modules::geometry::Line &>(&modules::geometry::distance),
-        "Returns euclidean distance between modules::geometry::Line2d and modules::geometry::Point2d.");
-        
+        "Returns euclidean distance between two modules::geometry::Line2d.");
+
   m.def("distance", py::overload_cast<const modules::geometry::Polygon &, const modules::geometry::Polygon &>(&modules::geometry::distance),
-        "Returns euclidean distance between polygon and polygon.");
+        "Returns euclidean distance between Polygon and Polygon.");
 
   m.def("distance", py::overload_cast<const modules::geometry::Polygon &, const modules::geometry::Line &>(&modules::geometry::distance),
-        "Returns euclidean distance between polygon and line2d.");
+        "Returns euclidean distance between Polygon and Line2d.");
 
   m.def("distance", py::overload_cast<const modules::geometry::Polygon &, const modules::geometry::Point2d &>(&modules::geometry::distance),
-        "Returns euclidean distance between polygon and point2d.");
+        "Returns euclidean distance between Polygon and Point2d.");
 
   m.def("get_nearest_point", &modules::geometry::get_nearest_point, "get the nearest point from point to a line.");
 
@@ -67,14 +67,14 @@ void python_geometry(py::module m) {
 
   m.def("get_tangent_angle_at_s", &modules::geometry::get_tangent_angle_at_s,
                                    "get the angle at position s of the line");
-  
-  m.def("get_nearest_point_and_s", &modules::geometry::get_nearest_point_and_s, 
+
+  m.def("get_nearest_point_and_s", &modules::geometry::get_nearest_point_and_s,
                         "get the point nearest to another point and its position on the line s ");
 
-  m.def("merge_bounding_boxes", &modules::geometry::merge_bounding_boxes<modules::geometry::Point2d>, 
+  m.def("merge_bounding_boxes", &modules::geometry::merge_bounding_boxes<modules::geometry::Point2d>,
                         "merge two bounding boxes consisting of pairs of min and max corners");
 
-  py::class_<modules::geometry::Line>(m, "Line2d")
+  py::class_<modules::geometry::Line, std::shared_ptr<modules::geometry::Line>>(m, "Line2d")
       .def(py::init<>(), "Create empty line")
       .def("addPoint", &modules::geometry::Line::add_point, "add a point")
       .def("addPoint", [](modules::geometry::Line &line, py::list list) {
@@ -116,7 +116,7 @@ void python_geometry(py::module m) {
             return l;
         }));
 
-  py::class_<modules::geometry::Polygon>(m, "Polygon2d")
+  py::class_<modules::geometry::Polygon, std::shared_ptr<modules::geometry::Polygon>>(m, "Polygon2d")
       .def(py::init<>(), "Create empty polygon")
       .def(py::init<modules::geometry::Pose, std::vector<modules::geometry::Point2d>>(), "Create polygon with center point and point list")
       .def(py::init<modules::geometry::Pose, const Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic> &>(), "Create polygon with center point and point list")


### PR DESCRIPTION
Two main contrib of this PR:
1. amend memory leak by replace ptr* with shared_ptr
    Use `Vec2d = using Point2d;` to represent vector/translate.
    Vec2d could be redefine in the future if new feature necessary.
2. unify distance calculation
```
inline float distance(const Point2d &p1, const Point2d &p2) {
-  float dx = bg::get<0>(p1) - bg::get<0>(p2);
-  float dy = bg::get<1>(p1) - bg::get<1>(p2);
-  return sqrt(dx * dx + dy * dy);
+  return bg::distance(p1, p2);
}
```