### PR TITLE
World: refresh local map when update goal definition

### DIFF
--- a/modules/world/objects/agent.hpp
+++ b/modules/world/objects/agent.hpp
@@ -89,6 +89,7 @@ class Agent : public Object {
 
   void set_goal_definition(const GoalDefinitionPtr &goal_definition) {
     goal_definition_ = goal_definition;
+    GenerateLocalMap();
   }
 
   void set_local_map(const modules::world::map::LocalMapPtr& local_map) {local_map_ = local_map; }


### PR DESCRIPTION
It is a good practice to refresh local map when updating goal definition.
We cannot guarantee that the users always call `GenerateLocalMap` after `set_goal_definition`.
Also, the `set_goal_definition` is not a frequency caller in the real world. We can afford the potential overhead, while we cannot tolerate the potential absent of `GenerateLocalMap`.