### PR TITLE
Fix behavior models

### DIFF
--- a/modules/models/behavior/motion_primitives/motion_primitives.cpp
+++ b/modules/models/behavior/motion_primitives/motion_primitives.cpp
@@ -24,12 +24,12 @@ BehaviorMotionPrimitives::BehaviorMotionPrimitives(const DynamicModelPtr& dynami
     {}
 
 dynamic::Trajectory BehaviorMotionPrimitives::Plan(
-    float delta_time,
-    const world::ObservedWorld& observed_world) {
+    float delta_time, const world::ObservedWorld& observed_world) {
   dynamic::State ego_vehicle_state = observed_world.current_ego_state();
   double start_time = observed_world.get_world_time();
-   const float dt = integration_time_delta_; 
-  const int num_trajectory_points = static_cast<int>(std::ceil(delta_time / dt))+1;
+  const float dt = integration_time_delta_;
+  const int num_trajectory_points =
+      static_cast<int>(std::ceil(delta_time / dt)) + 1;
 
   dynamic::Trajectory traj(num_trajectory_points, int(dynamic::StateDefinition::MIN_STATE_SIZE));
 
@@ -51,12 +51,12 @@ dynamic::Trajectory BehaviorMotionPrimitives::Plan(
     old_state(StateDefinition::VEL_POSITION) = traj(trajectory_idx-1, StateDefinition::VEL_POSITION);
 
     float integration_time = dt;
-    if(trajectory_idx == num_trajectory_points-1) {
-      integration_time = delta_time - trajectory_idx*dt;
+    if (trajectory_idx == num_trajectory_points - 1) {
+      integration_time = delta_time - (trajectory_idx - 1) * dt;
     }
-    
+
     auto state = dynamic::euler_int(*dynamic_model_, old_state, motion_primitives_[active_motion_], integration_time);
-    traj(trajectory_idx, StateDefinition::TIME_POSITION) = start_time + trajectory_idx*dt;
+    traj(trajectory_idx, StateDefinition::TIME_POSITION) = start_time + (trajectory_idx - 1) * dt + integration_time;
     traj(trajectory_idx, StateDefinition::X_POSITION) = state(StateDefinition::X_POSITION);
     traj(trajectory_idx, StateDefinition::Y_POSITION) = state(StateDefinition::Y_POSITION);
     traj(trajectory_idx, StateDefinition::THETA_POSITION) = state(StateDefinition::THETA_POSITION);

--- a/modules/models/tests/BUILD
+++ b/modules/models/tests/BUILD
@@ -44,6 +44,23 @@ cc_test(
 )
 
 cc_test(
+    name = "behavior_longitudinal_acceleration_test",
+    srcs = [
+        "behavior_longitudinal_acceleration_test.cc",
+    ],
+    copts = ["-Iexternal/gtest/include"],
+    deps = [
+        ":make_test_world",
+        "//modules/geometry",
+        "//modules/models/behavior/longitudinal_acceleration",
+        "//modules/models/dynamic",
+        "//modules/world",
+        "@com_github_eigen_eigen//:eigen",
+        "@gtest//:main",
+    ],
+)
+
+cc_test(
     name = "behavior_idm_classic_test",
     srcs = [
         "behavior_idm_classic_test.cc",

--- a/modules/models/tests/behavior_longitudinal_acceleration_test.cc
+++ b/modules/models/tests/behavior_longitudinal_acceleration_test.cc
@@ -1,0 +1,73 @@
+// Copyright (c) 2019 fortiss GmbH
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "Eigen/Core"
+#include "gtest/gtest.h"
+
+#include "make_test_world.hpp"
+#include "modules/commons/params/default_params.hpp"
+#include "modules/commons/params/setter_params.hpp"
+#include "modules/geometry/commons.hpp"
+#include "modules/geometry/line.hpp"
+#include "modules/geometry/polygon.hpp"
+#include "modules/models/behavior/longitudinal_acceleration/longitudinal_acceleration.hpp"
+#include "modules/models/dynamic/single_track.hpp"
+#include "modules/world/observed_world.hpp"
+
+using namespace modules::models::dynamic;
+using namespace modules::models::execution;
+using namespace modules::commons;
+using namespace modules::models::behavior;
+using namespace modules::models::dynamic;
+using namespace modules::world;
+using namespace modules::geometry;
+using namespace modules::models::tests;
+
+// Acceleration
+const double a = 10.0;
+
+class DummyConstantAcceleration : public BehaviorLongitudinalAcceleration {
+ public:
+  using BehaviorLongitudinalAcceleration::BehaviorLongitudinalAcceleration;
+  virtual double CalculateLongitudinalAcceleration(
+      const ObservedWorld& observed_world) {
+    return a;
+  };
+
+  virtual std::shared_ptr<BehaviorModel> Clone() const {
+    std::shared_ptr<DummyConstantAcceleration> model_ptr =
+        std::make_shared<DummyConstantAcceleration>(*this);
+    return std::dynamic_pointer_cast<BehaviorModel>(model_ptr);
+  };
+};
+
+TEST(behavior_constant_acceleration_plan, behavior_test) {
+  SetterParams* params = new SetterParams();
+  DummyConstantAcceleration behavior(params);
+
+  const double dt = 1.0;
+
+  // X Longitudinal with zero velocity
+  ObservedWorld obs_world = make_test_observed_world(0, 0, 0, 0);
+
+  Trajectory traj1 = behavior.Plan(1, obs_world);
+  // s = 1/2 * a * t^2 + v_0*t
+  double delta_s = 0.5 * a * dt * dt;
+  EXPECT_EQ(1, traj1(traj1.rows() - 1, StateDefinition::TIME_POSITION));
+  EXPECT_NEAR(
+      delta_s + obs_world.get_ego_agent()->get_current_position().get<0>(),
+      traj1(traj1.rows() - 1, StateDefinition::X_POSITION), .1e-4);
+
+  // X Longitudinal with 5 m/s initial velocity
+  const double v_0 = 5.0;
+  auto obs_world1 = make_test_observed_world(0, 0, v_0, 0);
+  Trajectory traj2 = behavior.Plan(1, obs_world1);
+  // s = 1/2 * a * t^2 + v_0*t
+  delta_s = 0.5 * a * dt * dt + v_0 * dt;
+  EXPECT_EQ(1, traj1(traj2.rows() - 1, StateDefinition::TIME_POSITION));
+  EXPECT_NEAR(
+      delta_s + obs_world1.get_ego_agent()->get_current_position().get<0>(),
+      traj2(traj2.rows() - 1, StateDefinition::X_POSITION), .1e-4);
+}

--- a/modules/models/tests/behavior_motion_primitive_test.cc
+++ b/modules/models/tests/behavior_motion_primitive_test.cc
@@ -63,6 +63,9 @@ TEST(behavior_motion_primitives_plan, behavior_test) {
   Input u2(2);
   u2 << 0, 1;
   BehaviorMotionPrimitives::MotionIdx idx2 = behavior.AddMotionPrimitive(u2);
+  Input u3(2);
+  u3 << 0, 0;
+  BehaviorMotionPrimitives::MotionIdx idx3 = behavior.AddMotionPrimitive(u3);
 
   // X Longitudinal with zero velocity
   State init_state(static_cast<int>(StateDefinition::MIN_STATE_SIZE));
@@ -92,6 +95,15 @@ TEST(behavior_motion_primitives_plan, behavior_test) {
   EXPECT_NEAR(traj1(traj1.rows() - 1,
                     StateDefinition::Y_POSITION),
               2/2*0.5*0.5, 0.05);
+
+  // X Constant motion
+  init_state << 0.0, 0.0, 0.0, 0.0, 2.0;
+  DummyObservedWorld world3(init_state, params);
+  behavior.ActionToBehavior(idx3);
+  Trajectory traj3 = behavior.Plan(0.5, world3);
+  EXPECT_NEAR(traj3(traj3.rows() - 1,
+                    StateDefinition::X_POSITION),
+              0.5 * 2, 0.005);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Fixes problems in:

`BehaviorLongitudinalAcceleration`:

* If `delta_time` is evenly divisible by the `integration_time`, the last point in the trajectory has its time advanced, but for the rest of the state vector `integration_time = 0` was used.

`BehaviorLongitudinalAcceleration`:

* Last point missing in trajectory
* Acceleration not considered when calculating `ds`