### PR TITLE
Simplify poly intersect

### DIFF
--- a/modules/geometry/polygon.hpp
+++ b/modules/geometry/polygon.hpp
@@ -7,6 +7,7 @@
 #ifndef MODULES_GEOMETRY_POLYGON_HPP_
 #define MODULES_GEOMETRY_POLYGON_HPP_
 
+#include <memory>
 #include <vector>
 
 #include <boost/geometry.hpp>
@@ -21,7 +22,7 @@ namespace geometry {
 template <typename T>
 struct Polygon_t : public Shape<bg::model::polygon<T>, T> {
   Polygon_t();
-  virtual ~Polygon_t(){};
+  virtual ~Polygon_t() {}
   Polygon_t(const Pose& center, const std::vector<T> points);
   Polygon_t(const Pose& center,
             const Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic>& points);
@@ -187,7 +188,7 @@ inline bool Collide(const Polygon& poly1, const Polygon& poly2) {
 }
 
 inline bool ShrinkPolygon(const Polygon& polygon, const double distance,
-                          Polygon& shrunk_polygon) {
+                          Polygon* shrunk_polygon) {
   namespace bg = boost::geometry;
   namespace bbuf = bg::strategy::buffer;
 
@@ -209,9 +210,9 @@ inline bool ShrinkPolygon(const Polygon& polygon, const double distance,
 
   for (auto const& point :
        boost::make_iterator_range(bg::exterior_ring(shrunk_polygons.front()))) {
-    shrunk_polygon.add_point(point);
+    shrunk_polygon->add_point(point);
   }
-  assert(shrunk_polygon.Valid());
+  assert(shrunk_polygon->Valid());
   return true;
 }
 

--- a/modules/geometry/polygon.hpp
+++ b/modules/geometry/polygon.hpp
@@ -173,23 +173,7 @@ inline bool Within(const Line& l, const Polygon& poly) {
 //! @note we only check the shape intersection(s) and no line RHS/LHS line
 //! crossing!
 inline bool Collide(const Polygon& poly, const Line& l) {
-  std::vector<bg::model::linestring<LinePoint>> shape_intersect;
-  bg::intersection(poly.obj_, l.obj_, shape_intersect);
-  const bool inner_intersection = !shape_intersect.empty();
-  if (inner_intersection) {
-    return inner_intersection;
-  } else {
-    // boost interection does not treat edge intersections as intersection1,
-    // but this shall be a collision! -> cast poly edge to line and re-check
-    // collision.
-    Line outer_polyline;
-    //! @todo geht das eleganter?
-    for (auto it = boost::begin(boost::geometry::exterior_ring(poly.obj_));
-         it != boost::end(boost::geometry::exterior_ring(poly.obj_)); ++it) {
-      outer_polyline.add_point(*it);
-    }
-    return Collide(outer_polyline, l);
-  }
+  return bg::intersects(poly.obj_, l.obj_);
 }
 
 //! Line - Polygon collision checker using boost::intersection
@@ -197,31 +181,9 @@ inline bool Collide(const Line& line, const Polygon& poly) {
   return Collide(poly, line);
 }
 
-//! Polygon - Polygon collision checker using boost::intersection
-//! @todo might not be very efficient without Strategy...
+//! Polygon - Polygon collision checker using boost::intersects
 inline bool Collide(const Polygon& poly1, const Polygon& poly2) {
-  std::vector<bg::model::polygon<PolygonPoint>> shape_intersect;
-  bg::intersection(poly1.obj_, poly2.obj_, shape_intersect);
-  const bool inner_intersection = !shape_intersect.empty();
-  if (inner_intersection) {
-    return inner_intersection;
-  } else {
-    // boost interection does not treat edge intersections as intersection,
-    // but this shall be a collision! -> cast poly edge to line and re-check
-    // collision.
-    Line outer_polyline1;
-    Line outer_polyline2;
-    //! @todo geht das eleganter?
-    for (auto it = boost::begin(boost::geometry::exterior_ring(poly1.obj_));
-         it != boost::end(boost::geometry::exterior_ring(poly1.obj_)); ++it) {
-      outer_polyline1.add_point(*it);
-    }
-    for (auto it = boost::begin(boost::geometry::exterior_ring(poly2.obj_));
-         it != boost::end(boost::geometry::exterior_ring(poly2.obj_)); ++it) {
-      outer_polyline2.add_point(*it);
-    }
-    return Collide(outer_polyline1, outer_polyline2);
-  }
+  return bg::intersects(poly1.obj_, poly2.obj_);
 }
 
 inline bool ShrinkPolygon(const Polygon& polygon, const double distance,

--- a/modules/geometry/tests/geometry_test.cc
+++ b/modules/geometry/tests/geometry_test.cc
@@ -11,8 +11,10 @@
 #include "modules/geometry/standard_shapes.hpp"
 
 TEST(polygon, base_functionality) {
-  using namespace std;
-  using namespace modules::geometry;
+  using modules::geometry::Point2d;
+  using modules::geometry::Point2d_t;
+  using modules::geometry::Polygon;
+  using modules::geometry::Polygon_t;
 
   // template version; point <--> polygon
   Point2d_t<float> point_1(0.0, 0.0);
@@ -46,8 +48,9 @@ TEST(polygon, base_functionality) {
 }
 
 TEST(line, base_functionality) {
-  using namespace std;
-  using namespace modules::geometry;
+  using modules::geometry::Line_t;
+  using modules::geometry::Point2d;
+  using modules::geometry::Point2d_t;
 
   // template
   Point2d point_1(0.0, 1.0);
@@ -66,8 +69,9 @@ TEST(line, base_functionality) {
 }
 
 TEST(geometry, line) {
-  using namespace std;
-  using namespace modules::geometry;
+  using modules::geometry::Line;
+  using modules::geometry::Point2d;
+  using modules::geometry::Polygon;
   namespace bg = boost::geometry;
 
   Line l;  // vertical
@@ -127,9 +131,8 @@ TEST(geometry, line) {
 }
 
 TEST(geometry, polygon) {
-  using namespace std;
-  using namespace modules::geometry;
-  namespace bg = boost::geometry;
+  using modules::geometry::Point2d;
+  using modules::geometry::Polygon;
 
   Polygon p;
   p.add_point(Point2d(0, 0));
@@ -145,10 +148,8 @@ TEST(geometry, polygon) {
 }
 
 TEST(geometry, standard_shapes) {
-  using namespace std;
-  using namespace modules::geometry;
-  using namespace modules::geometry::standard_shapes;
-  namespace bg = boost::geometry;
+  using modules::geometry::Polygon;
+  using modules::geometry::standard_shapes::CarLimousine;
 
   Polygon p = CarLimousine();
   ASSERT_TRUE(p.Valid());
@@ -156,9 +157,9 @@ TEST(geometry, standard_shapes) {
 
 // poly point collide false
 TEST(collision, poly2point1) {
-  using namespace std;
-  using namespace modules::geometry;
-  namespace bg = boost::geometry;
+  using modules::geometry::Collide;
+  using modules::geometry::Point2d;
+  using modules::geometry::Polygon;
 
   Polygon p;
   p.add_point(Point2d(0, 0));
@@ -174,9 +175,9 @@ TEST(collision, poly2point1) {
 
 // poly point collide true
 TEST(collision, poly2point2) {
-  using namespace std;
-  using namespace modules::geometry;
-  namespace bg = boost::geometry;
+  using modules::geometry::Collide;
+  using modules::geometry::Point2d;
+  using modules::geometry::Polygon;
 
   Polygon p;
   p.add_point(Point2d(0, 0));
@@ -192,9 +193,9 @@ TEST(collision, poly2point2) {
 
 // poly poly collide false
 TEST(collision, poly2poly1) {
-  using namespace std;
-  using namespace modules::geometry;
-  namespace bg = boost::geometry;
+  using modules::geometry::Collide;
+  using modules::geometry::Point2d;
+  using modules::geometry::Polygon;
 
   Polygon p1;
   p1.add_point(Point2d(0, 0));
@@ -217,9 +218,9 @@ TEST(collision, poly2poly1) {
 
 // poly poly collide overlap true
 TEST(collision, poly2poly2) {
-  using namespace std;
-  using namespace modules::geometry;
-  namespace bg = boost::geometry;
+  using modules::geometry::Collide;
+  using modules::geometry::Point2d;
+  using modules::geometry::Polygon;
 
   Polygon p1;
   p1.add_point(Point2d(0, 0));
@@ -242,9 +243,9 @@ TEST(collision, poly2poly2) {
 
 // poly poly collide point overlap true
 TEST(collision, poly2poly3) {
-  using namespace std;
-  using namespace modules::geometry;
-  namespace bg = boost::geometry;
+  using modules::geometry::Collide;
+  using modules::geometry::Point2d;
+  using modules::geometry::Polygon;
 
   Polygon p1;
   p1.add_point(Point2d(0, 0));
@@ -267,59 +268,60 @@ TEST(collision, poly2poly3) {
 
 // poly poly collide edge overlap true
 TEST(collision, poly2poly4) {
-using namespace std;
-using namespace modules::geometry;
-namespace bg = boost::geometry;
+  using modules::geometry::Collide;
+  using modules::geometry::Point2d;
+  using modules::geometry::Polygon;
 
-Polygon p1;
-p1.add_point(Point2d(0, 0));
-p1.add_point(Point2d(0, 1));
-p1.add_point(Point2d(1, 1));
-p1.add_point(Point2d(1, 0));
-p1.add_point(Point2d(0, 0));
+  Polygon p1;
+  p1.add_point(Point2d(0, 0));
+  p1.add_point(Point2d(0, 1));
+  p1.add_point(Point2d(1, 1));
+  p1.add_point(Point2d(1, 0));
+  p1.add_point(Point2d(0, 0));
 
-Polygon p2;
-p2.add_point(Point2d(1, 1));
-p2.add_point(Point2d(2, 1));
-p2.add_point(Point2d(2, 0));
-p2.add_point(Point2d(1, 0));
-p2.add_point(Point2d(1, 1));
+  Polygon p2;
+  p2.add_point(Point2d(1, 1));
+  p2.add_point(Point2d(2, 1));
+  p2.add_point(Point2d(2, 0));
+  p2.add_point(Point2d(1, 0));
+  p2.add_point(Point2d(1, 1));
 
-EXPECT_TRUE(Collide(p1, p2));
+  EXPECT_TRUE(Collide(p1, p2));
 
-EXPECT_TRUE(Collide(p2, p1));
+  EXPECT_TRUE(Collide(p2, p1));
 }
 
 // poly poly collide ccw true
 TEST(collision, poly2poly5) {
-using namespace std;
-using namespace modules::geometry;
-namespace bg = boost::geometry;
+  using modules::geometry::Collide;
+  using modules::geometry::Point2d;
+  using modules::geometry::Polygon;
 
-Polygon p1;
-p1.add_point(Point2d(0, 0));
-p1.add_point(Point2d(0, 1));
-p1.add_point(Point2d(1, 1));
-p1.add_point(Point2d(1, 0));
-p1.add_point(Point2d(0, 0));
+  Polygon p1;
+  p1.add_point(Point2d(0, 0));
+  p1.add_point(Point2d(0, 1));
+  p1.add_point(Point2d(1, 1));
+  p1.add_point(Point2d(1, 0));
+  p1.add_point(Point2d(0, 0));
 
-Polygon p2;
-p2.add_point(Point2d(1.5, 1.5));
-p2.add_point(Point2d(0.5, 1.5));
-p2.add_point(Point2d(0.5, 0.5));
-p2.add_point(Point2d(1.5, 0.5));
-p2.add_point(Point2d(1.5, 1.5));
+  Polygon p2;
+  p2.add_point(Point2d(1.5, 1.5));
+  p2.add_point(Point2d(0.5, 1.5));
+  p2.add_point(Point2d(0.5, 0.5));
+  p2.add_point(Point2d(1.5, 0.5));
+  p2.add_point(Point2d(1.5, 1.5));
 
-EXPECT_TRUE(Collide(p1, p2));
+  EXPECT_TRUE(Collide(p1, p2));
 
-EXPECT_TRUE(Collide(p2, p1));
+  EXPECT_TRUE(Collide(p2, p1));
 }
 
 // poly line collision no collision
 TEST(collision, poly2line1) {
-  using namespace std;
-  using namespace modules::geometry;
-  namespace bg = boost::geometry;
+  using modules::geometry::Collide;
+  using modules::geometry::Line;
+  using modules::geometry::Point2d;
+  using modules::geometry::Polygon;
 
   Polygon p1;
   p1.add_point(Point2d(0, 0));
@@ -337,9 +339,10 @@ TEST(collision, poly2line1) {
 
 // poly line collision line intersect
 TEST(collision, poly2line2) {
-  using namespace std;
-  using namespace modules::geometry;
-  namespace bg = boost::geometry;
+  using modules::geometry::Collide;
+  using modules::geometry::Line;
+  using modules::geometry::Point2d;
+  using modules::geometry::Polygon;
 
   Polygon p1;
   p1.add_point(Point2d(0, 0));
@@ -363,9 +366,10 @@ TEST(collision, poly2line2) {
 
 // poly line collision point intersect
 TEST(collision, poly2line3) {
-  using namespace std;
-  using namespace modules::geometry;
-  namespace bg = boost::geometry;
+  using modules::geometry::Collide;
+  using modules::geometry::Line;
+  using modules::geometry::Point2d;
+  using modules::geometry::Polygon;
 
   Polygon p1;
   p1.add_point(Point2d(0, 0));
@@ -383,9 +387,9 @@ TEST(collision, poly2line3) {
 
 // line point collision no intersect
 TEST(collision, line2point1) {
-  using namespace std;
-  using namespace modules::geometry;
-  namespace bg = boost::geometry;
+  using modules::geometry::Collide;
+  using modules::geometry::Line;
+  using modules::geometry::Point2d;
 
   Line l1;
   l1.add_point(Point2d(1, 1));
@@ -398,9 +402,9 @@ TEST(collision, line2point1) {
 
 // line point collision point intersect
 TEST(collision, line2point2) {
-  using namespace std;
-  using namespace modules::geometry;
-  namespace bg = boost::geometry;
+  using modules::geometry::Collide;
+  using modules::geometry::Line;
+  using modules::geometry::Point2d;
 
   Line l1;
   l1.add_point(Point2d(0, 0));
@@ -413,9 +417,9 @@ TEST(collision, line2point2) {
 
 // line point collision end point intersect
 TEST(collision, line2point3) {
-  using namespace std;
-  using namespace modules::geometry;
-  namespace bg = boost::geometry;
+  using modules::geometry::Collide;
+  using modules::geometry::Line;
+  using modules::geometry::Point2d;
 
   Line l1;
   l1.add_point(Point2d(1, 1));
@@ -428,9 +432,9 @@ TEST(collision, line2point3) {
 
 // line line collision no intersect
 TEST(collision, line2line1) {
-  using namespace std;
-  using namespace modules::geometry;
-  namespace bg = boost::geometry;
+  using modules::geometry::Collide;
+  using modules::geometry::Line;
+  using modules::geometry::Point2d;
 
   Line l1;
   l1.add_point(Point2d(1, 1));
@@ -445,10 +449,9 @@ TEST(collision, line2line1) {
 
 // line line collision point intersect
 TEST(collision, line2line2) {
-  using namespace std;
-  using namespace modules::geometry;
-  namespace bg = boost::geometry;
-
+  using modules::geometry::Collide;
+  using modules::geometry::Line;
+  using modules::geometry::Point2d;
   Line l1;
   l1.add_point(Point2d(1, 1));
   l1.add_point(Point2d(2, 2));
@@ -463,9 +466,9 @@ TEST(collision, line2line2) {
 
 // line line collision point intersect point
 TEST(collision, line2line3) {
-  using namespace std;
-  using namespace modules::geometry;
-  namespace bg = boost::geometry;
+  using modules::geometry::Collide;
+  using modules::geometry::Line;
+  using modules::geometry::Point2d;
 
   Line l1;
   l1.add_point(Point2d(1, 1));
@@ -481,10 +484,10 @@ TEST(collision, line2line3) {
 
 // car shape collision false
 TEST(collision, carshape1) {
-  using namespace std;
-  using namespace modules::geometry;
-  using namespace modules::geometry::standard_shapes;
-  namespace bg = boost::geometry;
+  using modules::geometry::Collide;
+  using modules::geometry::Polygon;
+  using modules::geometry::Pose;
+  using modules::geometry::standard_shapes::CarLimousine;
 
   Polygon outline = CarLimousine();
   std::shared_ptr<Polygon> car1 =
@@ -497,10 +500,10 @@ TEST(collision, carshape1) {
 
 // car shape collision true
 TEST(collision, carshape2) {
-  using namespace std;
-  using namespace modules::geometry;
-  using namespace modules::geometry::standard_shapes;
-  namespace bg = boost::geometry;
+  using modules::geometry::Collide;
+  using modules::geometry::Polygon;
+  using modules::geometry::Pose;
+  using modules::geometry::standard_shapes::CarLimousine;
 
   Polygon outline = CarLimousine();
   std::shared_ptr<Polygon> car1 =
@@ -513,8 +516,8 @@ TEST(collision, carshape2) {
 }
 
 TEST(line, s1) {
-  using namespace std;
-  using namespace modules::geometry;
+  using modules::geometry::Line_t;
+  using modules::geometry::Point2d;
 
   // template
   Point2d point_1(0.0, 1.0);
@@ -533,8 +536,8 @@ TEST(line, s1) {
 }
 
 TEST(line, s2) {
-  using namespace std;
-  using namespace modules::geometry;
+  using modules::geometry::Line_t;
+  using modules::geometry::Point2d;
 
   // template
   Point2d point_1(-1.0, 0.0);
@@ -549,7 +552,7 @@ TEST(line, s2) {
   line.add_point(point_3);
   line.add_point(point_4);
 
-  EXPECT_TRUE(line.s_.size() == 4);
+  EXPECT_EQ(line.s_.size(), 4u);
   EXPECT_DOUBLE_EQ(line.s_[0], 0.0);
   EXPECT_DOUBLE_EQ(line.s_[1], 1.0);
   EXPECT_DOUBLE_EQ(line.s_[2], 2.0);
@@ -557,8 +560,9 @@ TEST(line, s2) {
 }
 
 TEST(line, get_s_at_pt_1) {
-  using namespace std;
-  using namespace modules::geometry;
+  using modules::geometry::Line_t;
+  using modules::geometry::Point2d;
+  using modules::geometry::operator==;
 
   // template
   Point2d point_1(0.0, 1.0);
@@ -587,8 +591,9 @@ TEST(line, get_s_at_pt_1) {
 }
 
 TEST(line, get_line_from_s_interval) {
-  using namespace std;
-  using namespace modules::geometry;
+  using modules::geometry::Line_t;
+  using modules::geometry::Point2d;
+  using modules::geometry::operator==;
 
   Point2d point_1(0.0, 1.0);
   Point2d point_2(0.0, 2.0);
@@ -611,7 +616,9 @@ TEST(line, get_line_from_s_interval) {
   EXPECT_TRUE(Point2d(0.0, 2.5) == p3);
 }
 TEST(line, get_line_from_s_interval_entire_line) {
-  using namespace modules::geometry;
+  using modules::geometry::Line_t;
+  using modules::geometry::Point2d;
+  using modules::geometry::operator==;
 
   Point2d point_1(0.0, 0.0);
   Point2d point_2(0.0, 2.0);
@@ -628,8 +635,9 @@ TEST(line, get_line_from_s_interval_entire_line) {
 }
 
 TEST(line, get_nearest_point_1) {
-  using namespace std;
-  using namespace modules::geometry;
+  using modules::geometry::Line_t;
+  using modules::geometry::Point2d;
+  using modules::geometry::operator==;
 
   // template
   Point2d point_1(0.0, 1.0);
@@ -664,9 +672,8 @@ TEST(line, get_nearest_point_1) {
 }
 
 TEST(line, segment_intersection_check_1) {
-  using namespace std;
-  using namespace modules::geometry;
-
+  using modules::geometry::Line_t;
+  using modules::geometry::Point2d;
   // template
   Point2d point_1(0.0, 0.0);
   Point2d point_2(0.0, 1.0);
@@ -689,8 +696,8 @@ TEST(line, segment_intersection_check_1) {
   EXPECT_NEAR(get_segment_end_idx(line, 6.0), 5, 0.1f);
 }
 TEST(line, segment_intersection_tangent_1) {
-  using namespace std;
-  using namespace modules::geometry;
+  using modules::geometry::Line_t;
+  using modules::geometry::Point2d;
 
   // template
   Point2d point_1(0.0, 0.0);
@@ -731,8 +738,9 @@ TEST(line, segment_intersection_tangent_1) {
 }
 
 TEST(line, segment_get_normal_1) {
-  using namespace std;
-  using namespace modules::geometry;
+  using modules::geometry::Line_t;
+  using modules::geometry::Point2d;
+  namespace bg = boost::geometry;
 
   // template
   Point2d point_1(0.0, 0.0);
@@ -785,7 +793,7 @@ TEST(optimizer, shrink_polygon) {
   polygon.add_point(Point2d(0, 0));
 
   Polygon shrunk_polygon;
-  ShrinkPolygon(polygon, -1, shrunk_polygon);
+  ShrinkPolygon(polygon, -1, &shrunk_polygon);
 
   Polygon expected_shrunk_polygon;
   polygon.add_point(Point2d(1, 1));

--- a/modules/geometry/tests/geometry_test.cc
+++ b/modules/geometry/tests/geometry_test.cc
@@ -265,6 +265,56 @@ TEST(collision, poly2poly3) {
   EXPECT_TRUE(Collide(p2, p1));
 }
 
+// poly poly collide edge overlap true
+TEST(collision, poly2poly4) {
+using namespace std;
+using namespace modules::geometry;
+namespace bg = boost::geometry;
+
+Polygon p1;
+p1.add_point(Point2d(0, 0));
+p1.add_point(Point2d(0, 1));
+p1.add_point(Point2d(1, 1));
+p1.add_point(Point2d(1, 0));
+p1.add_point(Point2d(0, 0));
+
+Polygon p2;
+p2.add_point(Point2d(1, 1));
+p2.add_point(Point2d(2, 1));
+p2.add_point(Point2d(2, 0));
+p2.add_point(Point2d(1, 0));
+p2.add_point(Point2d(1, 1));
+
+EXPECT_TRUE(Collide(p1, p2));
+
+EXPECT_TRUE(Collide(p2, p1));
+}
+
+// poly poly collide ccw true
+TEST(collision, poly2poly5) {
+using namespace std;
+using namespace modules::geometry;
+namespace bg = boost::geometry;
+
+Polygon p1;
+p1.add_point(Point2d(0, 0));
+p1.add_point(Point2d(0, 1));
+p1.add_point(Point2d(1, 1));
+p1.add_point(Point2d(1, 0));
+p1.add_point(Point2d(0, 0));
+
+Polygon p2;
+p2.add_point(Point2d(1.5, 1.5));
+p2.add_point(Point2d(0.5, 1.5));
+p2.add_point(Point2d(0.5, 0.5));
+p2.add_point(Point2d(1.5, 0.5));
+p2.add_point(Point2d(1.5, 1.5));
+
+EXPECT_TRUE(Collide(p1, p2));
+
+EXPECT_TRUE(Collide(p2, p1));
+}
+
 // poly line collision no collision
 TEST(collision, poly2line1) {
   using namespace std;


### PR DESCRIPTION
Simplify collision checks of polygons by using `boost::intersects`. In contrast to `boost::intersection` it also handles edge collisions.