### PR TITLE
Update driving corridor for lane change

### DIFF
--- a/modules/world/map/local_map.cpp
+++ b/modules/world/map/local_map.cpp
@@ -59,6 +59,9 @@ bool LocalMap::Generate(Point2d point) {
   LanePtr current_lane = lanes.at(0);
 
   driving_corridor_ = map_interface_->ComputeDrivingCorridorFromStartToGoal(current_lane->get_id(), goal_lane_id_);
+  if (!driving_corridor_.computed) {
+    return false;
+  }
 
   return true;
 }

--- a/modules/world/map/roadgraph.cpp
+++ b/modules/world/map/roadgraph.cpp
@@ -272,7 +272,9 @@ std::pair<LaneId, bool> Roadgraph::get_outer_neighbor_but_not(
 
 std::vector<LaneId> Roadgraph::get_all_neighbors(const LaneId &lane_id) const {
   LanePtr lane = get_laneptr(lane_id);
-  assert(lane->get_lane_position() != 0);  // Does not work for the plan view
+  if (lane->get_lane_position() == 0) {
+    throw std::runtime_error("get_all_neighbors was called with the plan view");
+  }
 
   std::vector<LaneId> neighbors;
 

--- a/modules/world/map/roadgraph.cpp
+++ b/modules/world/map/roadgraph.cpp
@@ -81,7 +81,7 @@ std::vector<LaneId> Roadgraph::find_path(const LaneId &startid,
   std::pair<vertex_t, bool> goal_vertex = get_vertex_by_lane_id(goalid);
 
   // filter graph
-  DrivingLaneTypePredicate predicate{&g_};
+  LaneTypeDrivingAndEdgeTypeSuccessorPredicate predicate{&g_};
   FilteredLaneGraph fg(g_, predicate, predicate);
   bool start_goal_valid_in_fg = check_id_in_filtered_graph(fg, startid) &&
                                 check_id_in_filtered_graph(fg, goalid);
@@ -122,7 +122,6 @@ std::vector<LaneId> Roadgraph::find_path(const LaneId &startid,
       // std::cout << "current vertex " << current << " id " <<
       // fg[current].global_lane_id << std::endl;
       if (current == p[current]) {
-        std::cerr << "loop on itself -- probably not a valid path";
         return std::vector<LaneId>();
       }
       current = p[current];
@@ -269,6 +268,37 @@ std::pair<LaneId, bool> Roadgraph::get_outer_neighbor_but_not(
     }
   }
   return std::make_pair<LaneId, bool>(0, false);  // error case
+}
+
+std::vector<LaneId> Roadgraph::get_all_neighbors(const LaneId &lane_id) const {
+  LanePtr lane = get_laneptr(lane_id);
+  assert(lane->get_lane_position() != 0);  // Does not work for the plan view
+
+  std::vector<LaneId> neighbors;
+
+  std::pair<LaneId, bool> current_neighbor = get_inner_neighbor(lane_id);
+  std::pair<LaneId, bool> next_neighbor = std::make_pair(0, false);
+
+  // Inner neighbors
+  if (current_neighbor.second) {
+    // We do not want to add the planview to the vector of neighbors, therefore
+    // check if the current neighbor has an inner neighbor
+    next_neighbor = get_inner_neighbor(current_neighbor.first);
+  }
+  while (next_neighbor.second) {
+    neighbors.push_back(current_neighbor.first);
+    current_neighbor = next_neighbor;
+    next_neighbor = get_inner_neighbor(current_neighbor.first);
+  }
+
+  // Outer neighbors
+  current_neighbor = get_outer_neighbor(lane_id);
+  while (current_neighbor.second) {
+    neighbors.push_back(current_neighbor.first);
+    current_neighbor = get_outer_neighbor(current_neighbor.first);
+  }
+
+  return neighbors;
 }
 
 bool Roadgraph::has_lane(const LaneId &lane_id) const {

--- a/modules/world/map/roadgraph.hpp
+++ b/modules/world/map/roadgraph.hpp
@@ -56,12 +56,13 @@ typedef boost::adjacency_list<vecS, vecS, bidirectionalS, LaneVertex, LaneEdge> 
 typedef boost::graph_traits<LaneGraph>::vertex_descriptor vertex_t;
 typedef boost::graph_traits<LaneGraph>::edge_descriptor edge_t;
 
-struct DrivingLaneTypePredicate { // both edge and vertex
+struct LaneTypeDrivingAndEdgeTypeSuccessorPredicate { // both edge and vertex
   bool operator()(LaneGraph::edge_descriptor ed) const      { 
     bool filtered_s = (*g)[boost::source(ed, *g)].lane->get_lane_type()==LaneType::DRIVING;
     bool filtered_t = (*g)[boost::target(ed, *g)].lane->get_lane_type()==LaneType::DRIVING;
+    bool filtered_e = (*g)[ed].edge_type==LaneEdgeType::SUCCESSOR_EDGE;
         
-    bool filtered = filtered_s && filtered_t;
+    bool filtered = filtered_s && filtered_t && filtered_e;
     return filtered; 
   } 
       
@@ -72,7 +73,7 @@ struct DrivingLaneTypePredicate { // both edge and vertex
   LaneGraph* g;
 };
 
-typedef boost::filtered_graph<LaneGraph, DrivingLaneTypePredicate, DrivingLaneTypePredicate> FilteredLaneGraph;
+typedef boost::filtered_graph<LaneGraph, LaneTypeDrivingAndEdgeTypeSuccessorPredicate, LaneTypeDrivingAndEdgeTypeSuccessorPredicate> FilteredLaneGraph;
 
 class Roadgraph {
  public:
@@ -114,6 +115,10 @@ class Roadgraph {
   //! @param lane_id queried lane id
   //! @param from the query answer return the lane id that is not but_not
   std::pair<LaneId, bool> get_outer_neighbor_but_not(const LaneId& lane_id, const LaneId& but_not);
+
+  //! LaneIds of all neighboring lanes in the same driving direction. Includes neighbors of neighbors
+  //! @note cannot be called with the planview lane!
+  std::vector<LaneId> get_all_neighbors(const LaneId &lane_id) const;
 
   bool has_lane(const LaneId& lane_id) const;
 

--- a/modules/world/world.cpp
+++ b/modules/world/world.cpp
@@ -68,6 +68,7 @@ void World::DoExecution(const float& delta_time) {
   if (remove_agents_) {
     RemoveOutOfMapAgents();
   }
+  RegenerateDrivingCorridors();
 }
 
 WorldPtr World::WorldExecutionAtTime(const float& execution_time) const {
@@ -139,6 +140,19 @@ void World::RemoveOutOfMapAgents() {
     agents_.erase(result_pair.second);
   }
   UpdateAgentRTree();
+}
+
+void World::RegenerateDrivingCorridors() {
+  for (auto &agent : agents_) {
+    map::DrivingCorridor driving_corridor = 
+        agent.second->get_local_map()->get_driving_corridor();
+    geometry::Polygon corridor_polygon = driving_corridor.CorridorPolygon();
+    Point2d position = agent.second->get_current_position();
+
+    if (!geometry::Collide(corridor_polygon, position)) {
+      agent.second->GenerateLocalMap();
+    }
+  }
 }
 
 AgentMap World::GetNearestAgents(const modules::geometry::Point2d& position,

--- a/modules/world/world.hpp
+++ b/modules/world/world.hpp
@@ -98,6 +98,7 @@ class World : public commons::BaseType {
 
   void UpdateAgentRTree();
   void RemoveOutOfMapAgents();
+  void RegenerateDrivingCorridors();
   AgentMap GetNearestAgents(const modules::geometry::Point2d& position,
                             const unsigned int& num_agents) const;
   AgentMap GetAgentsIntersectingPolygon(


### PR DESCRIPTION
The behavior model of an agent can cause it to leave its driving corridor, for example when changing lane to overtake an obstacle. In order to still be able to plan a trajectory, the driving corridor of the agent should be updated in this case.

With this pull request, World will attempt to find a new driving corridor for an agent that has moved outside of its old one.
Additionally, it is now also possible to find a driving corridor to a final lane that is parallel to the goal lane, using only successor edges of the roadgraph.