### PR TITLE
Update driving corridor for lane change

### DIFF
--- a/modules/models/tests/make_test_world.cpp
+++ b/modules/models/tests/make_test_world.cpp
@@ -184,3 +184,101 @@ MapInterface modules::models::tests::make_two_lane_map_interface() {
 
   return map_interface;
 }
+
+MapInterface modules::models::tests::make_map_interface_two_connected_roads() {
+  using namespace modules::world::opendrive;
+  using namespace modules::geometry;
+
+  OpenDriveMapPtr map(new OpenDriveMap());
+
+  //! ROAD 1
+  PlanViewPtr p0(new PlanView());
+  p0->add_line(Point2d(0.0f, 0.0f), 0.0f, 10.0f);
+
+  //! Lane-Section 1
+  LaneSectionPtr ls0(new LaneSection(0.0));
+
+  //! PlanView
+  LaneOffset off0 = {0.0f, 0.0f, 0.0f, 0.0f};
+  LaneWidth lane_width_0 = {0, 10, off0};
+  LanePtr lane00 = create_lane_from_lane_width(0,
+                                               p0->get_reference_line(),
+                                               lane_width_0,
+                                               0.05);
+  lane00->set_lane_type(LaneType::DRIVING);
+
+  //! Lane
+  LaneOffset off = {1.0f, 0.0f, 0.0f, 0.0f};
+  LaneWidth lane_width_1 = {0, 10, off};
+  LanePtr lane01 = create_lane_from_lane_width(1,
+                                               p0->get_reference_line(),
+                                               lane_width_1,
+                                               0.05);
+  lane01->set_lane_type(LaneType::DRIVING);
+
+  LanePtr lane02 = create_lane_from_lane_width(2,
+                                               p0->get_reference_line(),
+                                               lane_width_1,
+                                               0.05);
+  lane02->set_lane_type(LaneType::DRIVING);
+
+  ls0->add_lane(lane00);
+  ls0->add_lane(lane01);
+  ls0->add_lane(lane02);
+
+  RoadPtr r0(new Road("highway", 100));
+  r0->set_plan_view(p0);
+  r0->add_lane_section(ls0);
+
+  map->add_road(r0);
+
+  //! ROAD 2
+  PlanViewPtr p1(new PlanView());
+  p1->add_line(Point2d(10.0f, 0.0f), 0.0f, 10.0f);
+
+  //! Lane-Section 2
+  LaneSectionPtr ls1(new LaneSection(0.0f));
+
+  //! PlanView
+  LanePtr lane10 = create_lane_from_lane_width(0,
+                                               p1->get_reference_line(),
+                                               lane_width_0,
+                                               0.05);
+  lane10->set_lane_type(LaneType::DRIVING);
+  lane10->set_link({0, 0});
+  
+
+  //! Lane
+  LanePtr lane11 = create_lane_from_lane_width(1,
+                                               p1->get_reference_line(),
+                                               lane_width_1,
+                                               0.05);
+  lane11->set_lane_type(LaneType::DRIVING);
+  lane11->set_link({1, 1});
+
+  LanePtr lane12 = create_lane_from_lane_width(2,
+                                               p1->get_reference_line(),
+                                               lane_width_1,
+                                               0.05);
+  lane12->set_lane_type(LaneType::DRIVING);
+  lane12->set_link({2, 2});
+
+  ls1->add_lane(lane10);
+  ls1->add_lane(lane11);
+  ls1->add_lane(lane12);
+
+  RoadPtr r1(new Road("highway", 101));
+  r1->set_plan_view(p1);
+  r1->add_lane_section(ls1);
+
+  map->add_road(r1);
+
+  RoadLinkInfo predecessor(100, "road");
+  RoadLinkInfo successor(101, "road");
+  r1->set_link(RoadLink(predecessor, successor));
+
+  modules::world::map::MapInterface map_interface;
+  map_interface.interface_from_opendrive(map);
+
+  return map_interface;
+}

--- a/modules/models/tests/make_test_world.hpp
+++ b/modules/models/tests/make_test_world.hpp
@@ -34,6 +34,8 @@ modules::world::ObservedWorld make_test_observed_world(int num_other_agents,
 
 modules::world::map::MapInterface make_two_lane_map_interface();
 
+modules::world::map::MapInterface make_map_interface_two_connected_roads();
+
 } // namespace tests
 } // namespace models
 } // namespace modules

--- a/modules/runtime/scenario/scenario_generation/uniform_vehicle_distribution.py
+++ b/modules/runtime/scenario/scenario_generation/uniform_vehicle_distribution.py
@@ -168,14 +168,19 @@ class UniformVehicleDistribution(ScenarioGeneration):
     
     # EGO Agent Goal Definition
     if  len(self._ego_goal_start) == 0:
-        goal_polygon = Polygon2d([0, 0, 0],
-                                [Point2d(-1.5,0),
-                                Point2d(-1.5,8),
-                                Point2d(1.5,8),
-                                Point2d(1.5,0)])
-        goal_polygon = goal_polygon.translate(Point2d(self._ego_goal_end[0],
-                                                    self._ego_goal_end[1]))
-        ego_agent.goal_definition = GoalDefinitionPolygon(goal_polygon)
+        if len(self._ego_route) == 0:
+          # ego agent is one of the random agents, so the goal definition is
+          # already set
+          pass
+        else:
+          goal_polygon = Polygon2d([0, 0, 0],
+                                   [Point2d(-1.5,0),
+                                    Point2d(-1.5,8),
+                                    Point2d(1.5,8),
+                                    Point2d(1.5,0)])
+          goal_polygon = goal_polygon.translate(Point2d(self._ego_goal_end[0],
+                                                      self._ego_goal_end[1]))
+          ego_agent.goal_definition = GoalDefinitionPolygon(goal_polygon)
         ego_agent.generate_local_map()
     else:
         connecting_center_line, s_start, s_end, _, lane_id_end = \

--- a/modules/world/map/local_map.cpp
+++ b/modules/world/map/local_map.cpp
@@ -66,6 +66,31 @@ bool LocalMap::Generate(Point2d point) {
   return true;
 }
 
+bool LocalMap::RecalculateDrivingCorridor(const Point2d &point) {
+  if (map_interface_ == nullptr) {
+    return false;
+  }
+
+  std::vector<LanePtr> lanes;
+  map_interface_->FindNearestLanes(point, 1, lanes);
+  LanePtr current_lane = lanes.at(0);
+
+  driving_corridor_ = map_interface_->ComputeDrivingCorridorFromStartToGoal(current_lane->get_id(), goal_lane_id_);
+  if (!driving_corridor_.computed) {
+    // No direct corridor to the goal lane exists, try finding a corridor parallel to the goal lane
+    driving_corridor_ = map_interface_->ComputeDrivingCorridorParallelToGoal(current_lane->get_id(), goal_lane_id_);
+  }
+  if (!driving_corridor_.computed) {
+    // TODO(@AKreutz): Maybe it is still possible to generate a driving corridor in this case?
+    LOG(ERROR) << "Driving corridor generation failed, goal lane " << goal_lane_id_
+               << " is not reachable from lane " << current_lane->get_id()
+               << ", neither are any of its neighboring lanes" << std::endl;
+    return false;
+  } else {
+    return true;
+  }
+}
+
 
 
 Line LocalMap::CalculateLineHorizon(const Line& line,

--- a/modules/world/map/local_map.cpp
+++ b/modules/world/map/local_map.cpp
@@ -59,6 +59,9 @@ bool LocalMap::Generate(Point2d point) {
   LanePtr current_lane = lanes.at(0);
 
   driving_corridor_ = map_interface_->ComputeDrivingCorridorFromStartToGoal(current_lane->get_id(), goal_lane_id_);
+  if (!driving_corridor_.computed) {
+    return false;
+  }
 
   return true;
 }

--- a/modules/world/map/local_map.hpp
+++ b/modules/world/map/local_map.hpp
@@ -95,6 +95,7 @@ class LocalMap {
   bool HasCorrectDrivingDirection(const State& state) const;
 
   bool Generate(Point2d point);
+  bool RecalculateDrivingCorridor(const Point2d &point);
   Line CalculateLineHorizon(const Line& line, const Point2d& p, double horizon);
 
   bool ComputeHorizonCorridor(const Point2d& p, double horizon);

--- a/modules/world/map/map_interface.cpp
+++ b/modules/world/map/map_interface.cpp
@@ -202,25 +202,23 @@ DrivingCorridor MapInterface::ComputeDrivingCorridorFromStartToGoal(
   const LaneId &startid, const LaneId &goalid)
 {
   std::vector<LaneId> ids = roadgraph_->find_path(startid, goalid);
-  if (ids.empty()) {
-    // The goal lane is not a successor of the start lane, check if they are
-    // parallel
-    std::vector<LaneId> goal_neighbors = roadgraph_->get_all_neighbors(goalid);
-    for (auto const &goal_neighbor : goal_neighbors) {
-      ids = roadgraph_->find_path(startid, goal_neighbor);
-      if (ids.size() > 0) {
-        // Found a target lane that is parallel to the goal lane
-        break;
-      }
+  return ComputeDrivingCorridorForRange(ids);
+}
+
+DrivingCorridor MapInterface::ComputeDrivingCorridorParallelToGoal(
+  const LaneId& startid, const LaneId& goalid)
+{
+  std::vector<LaneId> goal_neighbors = roadgraph_->get_all_neighbors(goalid);
+  for (auto const &goal_neighbor : goal_neighbors) {
+    std::vector<LaneId> ids = roadgraph_->find_path(startid, goal_neighbor);
+    if (ids.size() > 0) {
+      // Found a target lane that is parallel to the goal lane
+      return ComputeDrivingCorridorForRange(ids);
     }
   }
 
-  if (ids.empty()) {
-    // No lane parallel to the goal was found
-    return DrivingCorridor();
-  }
-
-  return ComputeDrivingCorridorForRange(ids);
+  // No lane parallel to the goal was found
+  return DrivingCorridor();
 }
 
 DrivingCorridor MapInterface::ComputeDrivingCorridorForRange(std::vector<LaneId> lane_ids)

--- a/modules/world/map/map_interface.cpp
+++ b/modules/world/map/map_interface.cpp
@@ -202,7 +202,11 @@ DrivingCorridor MapInterface::ComputeDrivingCorridorFromStartToGoal(
   const LaneId &startid, const LaneId &goalid)
 {
   std::vector<LaneId> ids = roadgraph_->find_path(startid, goalid);
-  return ComputeDrivingCorridorForRange(ids);
+  if (!ids.empty()) {
+    return ComputeDrivingCorridorForRange(ids);
+  } else {
+    return DrivingCorridor();
+  }
 }
 
 DrivingCorridor MapInterface::ComputeDrivingCorridorParallelToGoal(

--- a/modules/world/map/map_interface.hpp
+++ b/modules/world/map/map_interface.hpp
@@ -66,6 +66,10 @@ class MapInterface {
   
   DrivingCorridor ComputeDrivingCorridorFromStartToGoal(const LaneId& startid, const LaneId& goalid);
 
+  //! Compute a DrivingCorridor that ends in a lane neighboring the goal lane in
+  //! the same driving direction
+  DrivingCorridor ComputeDrivingCorridorParallelToGoal(const LaneId& startid, const LaneId& goalid);
+
   DrivingCorridor ComputeDrivingCorridorForRange(std::vector<LaneId> lane_ids);
 
   bool ComputeAllDrivingCorridors();

--- a/modules/world/map/map_interface.hpp
+++ b/modules/world/map/map_interface.hpp
@@ -64,10 +64,12 @@ class MapInterface {
   //std::pair< std::vector<LanePtr>, std::vector<LanePtr> > ComputeLaneBoundariesHorizon(
   //                                const LaneId& startid, const LaneId& goalid) const;
   
+  //! Compute a DrivingCorridor from the start lane to the goal lane. The goal
+  //! must be reachable without a lane change.
   DrivingCorridor ComputeDrivingCorridorFromStartToGoal(const LaneId& startid, const LaneId& goalid);
 
   //! Compute a DrivingCorridor that ends in a lane neighboring the goal lane in
-  //! the same driving direction
+  //! the same driving direction.
   DrivingCorridor ComputeDrivingCorridorParallelToGoal(const LaneId& startid, const LaneId& goalid);
 
   DrivingCorridor ComputeDrivingCorridorForRange(std::vector<LaneId> lane_ids);

--- a/modules/world/map/roadgraph.cpp
+++ b/modules/world/map/roadgraph.cpp
@@ -272,7 +272,9 @@ std::pair<LaneId, bool> Roadgraph::get_outer_neighbor_but_not(
 
 std::vector<LaneId> Roadgraph::get_all_neighbors(const LaneId &lane_id) const {
   LanePtr lane = get_laneptr(lane_id);
-  assert(lane->get_lane_position() != 0);  // Does not work for the plan view
+  if (lane->get_lane_position() == 0) {
+    throw std::runtime_error("get_all_neighbors was called with the plan view");
+  }
 
   std::vector<LaneId> neighbors;
 

--- a/modules/world/map/roadgraph.cpp
+++ b/modules/world/map/roadgraph.cpp
@@ -81,7 +81,7 @@ std::vector<LaneId> Roadgraph::find_path(const LaneId &startid,
   std::pair<vertex_t, bool> goal_vertex = get_vertex_by_lane_id(goalid);
 
   // filter graph
-  DrivingLaneTypePredicate predicate{&g_};
+  LaneTypeDrivingAndEdgeTypeSuccessorPredicate predicate{&g_};
   FilteredLaneGraph fg(g_, predicate, predicate);
   bool start_goal_valid_in_fg = check_id_in_filtered_graph(fg, startid) &&
                                 check_id_in_filtered_graph(fg, goalid);
@@ -122,7 +122,6 @@ std::vector<LaneId> Roadgraph::find_path(const LaneId &startid,
       // std::cout << "current vertex " << current << " id " <<
       // fg[current].global_lane_id << std::endl;
       if (current == p[current]) {
-        std::cerr << "loop on itself -- probably not a valid path";
         return std::vector<LaneId>();
       }
       current = p[current];
@@ -269,6 +268,37 @@ std::pair<LaneId, bool> Roadgraph::get_outer_neighbor_but_not(
     }
   }
   return std::make_pair<LaneId, bool>(0, false);  // error case
+}
+
+std::vector<LaneId> Roadgraph::get_all_neighbors(const LaneId &lane_id) const {
+  LanePtr lane = get_laneptr(lane_id);
+  assert(lane->get_lane_position() != 0);  // Does not work for the plan view
+
+  std::vector<LaneId> neighbors;
+
+  std::pair<LaneId, bool> current_neighbor = get_inner_neighbor(lane_id);
+  std::pair<LaneId, bool> next_neighbor = std::make_pair(0, false);
+
+  // Inner neighbors
+  if (current_neighbor.second) {
+    // We do not want to add the planview to the vector of neighbors, therefore
+    // check if the current neighbor has an inner neighbor
+    next_neighbor = get_inner_neighbor(current_neighbor.first);
+  }
+  while (next_neighbor.second) {
+    neighbors.push_back(current_neighbor.first);
+    current_neighbor = next_neighbor;
+    next_neighbor = get_inner_neighbor(current_neighbor.first);
+  }
+
+  // Outer neighbors
+  current_neighbor = get_outer_neighbor(lane_id);
+  while (current_neighbor.second) {
+    neighbors.push_back(current_neighbor.first);
+    current_neighbor = get_outer_neighbor(current_neighbor.first);
+  }
+
+  return neighbors;
 }
 
 bool Roadgraph::has_lane(const LaneId &lane_id) const {

--- a/modules/world/map/roadgraph.hpp
+++ b/modules/world/map/roadgraph.hpp
@@ -56,12 +56,13 @@ typedef boost::adjacency_list<vecS, vecS, bidirectionalS, LaneVertex, LaneEdge> 
 typedef boost::graph_traits<LaneGraph>::vertex_descriptor vertex_t;
 typedef boost::graph_traits<LaneGraph>::edge_descriptor edge_t;
 
-struct DrivingLaneTypePredicate { // both edge and vertex
+struct LaneTypeDrivingAndEdgeTypeSuccessorPredicate { // both edge and vertex
   bool operator()(LaneGraph::edge_descriptor ed) const      { 
     bool filtered_s = (*g)[boost::source(ed, *g)].lane->get_lane_type()==LaneType::DRIVING;
     bool filtered_t = (*g)[boost::target(ed, *g)].lane->get_lane_type()==LaneType::DRIVING;
+    bool filtered_e = (*g)[ed].edge_type==LaneEdgeType::SUCCESSOR_EDGE;
         
-    bool filtered = filtered_s && filtered_t;
+    bool filtered = filtered_s && filtered_t && filtered_e;
     return filtered; 
   } 
       
@@ -72,7 +73,7 @@ struct DrivingLaneTypePredicate { // both edge and vertex
   LaneGraph* g;
 };
 
-typedef boost::filtered_graph<LaneGraph, DrivingLaneTypePredicate, DrivingLaneTypePredicate> FilteredLaneGraph;
+typedef boost::filtered_graph<LaneGraph, LaneTypeDrivingAndEdgeTypeSuccessorPredicate, LaneTypeDrivingAndEdgeTypeSuccessorPredicate> FilteredLaneGraph;
 
 class Roadgraph {
  public:
@@ -114,6 +115,10 @@ class Roadgraph {
   //! @param lane_id queried lane id
   //! @param from the query answer return the lane id that is not but_not
   std::pair<LaneId, bool> get_outer_neighbor_but_not(const LaneId& lane_id, const LaneId& but_not);
+
+  //! LaneIds of all neighboring lanes in the same driving direction. Includes neighbors of neighbors
+  //! @note cannot be called with the planview lane!
+  std::vector<LaneId> get_all_neighbors(const LaneId &lane_id) const;
 
   bool has_lane(const LaneId& lane_id) const;
 

--- a/modules/world/objects/agent.cpp
+++ b/modules/world/objects/agent.cpp
@@ -123,9 +123,20 @@ void Agent::GenerateLocalMap() {
                    agent_state(StateDefinition::Y_POSITION));
   if (!local_map_->Generate(agent_xy)) {
     LOG(ERROR) << "LocalMap generation for agent "
-              << get_agent_id() << " failed." << std::endl;
+               << get_agent_id() << " failed." << std::endl;
   }
   // TODO(@hart): parameter
+  UpdateDrivingCorridor(20.0);
+}
+
+void Agent::RecalculateDrivingCorridor() {
+  if (local_map_ == nullptr) {
+    std::cout << "Local map is null" << std::endl;
+  }
+  if (!local_map_->RecalculateDrivingCorridor(get_current_position())) {
+    LOG(ERROR) << "DrivingCorridor generation for agent "
+               << get_agent_id() << " failed." << std::endl;
+  }
   UpdateDrivingCorridor(20.0);
 }
 

--- a/modules/world/objects/agent.cpp
+++ b/modules/world/objects/agent.cpp
@@ -130,9 +130,6 @@ void Agent::GenerateLocalMap() {
 }
 
 void Agent::RecalculateDrivingCorridor() {
-  if (local_map_ == nullptr) {
-    std::cout << "Local map is null" << std::endl;
-  }
   if (!local_map_->RecalculateDrivingCorridor(get_current_position())) {
     LOG(ERROR) << "DrivingCorridor generation for agent "
                << get_agent_id() << " failed." << std::endl;

--- a/modules/world/objects/agent.hpp
+++ b/modules/world/objects/agent.hpp
@@ -102,6 +102,7 @@ class Agent : public Object {
   bool AtGoal() const;
 
   void GenerateLocalMap();
+  void RecalculateDrivingCorridor();
   void UpdateDrivingCorridor(double horizon);
 
   virtual std::shared_ptr<Object> Clone() const;

--- a/modules/world/world.cpp
+++ b/modules/world/world.cpp
@@ -150,7 +150,7 @@ void World::RecalculateDrivingCorridors() {
     Point2d position = agent.second->get_current_position();
 
     if (!geometry::Collide(corridor_polygon, position)) {
-      agent.second->GenerateLocalMap();
+      agent.second->RecalculateDrivingCorridor();
     }
   }
 }

--- a/modules/world/world.cpp
+++ b/modules/world/world.cpp
@@ -68,7 +68,7 @@ void World::DoExecution(const float& delta_time) {
   if (remove_agents_) {
     RemoveOutOfMapAgents();
   }
-  RegenerateDrivingCorridors();
+  RecalculateDrivingCorridors();
 }
 
 WorldPtr World::WorldExecutionAtTime(const float& execution_time) const {
@@ -142,7 +142,7 @@ void World::RemoveOutOfMapAgents() {
   UpdateAgentRTree();
 }
 
-void World::RegenerateDrivingCorridors() {
+void World::RecalculateDrivingCorridors() {
   for (auto &agent : agents_) {
     map::DrivingCorridor driving_corridor = 
         agent.second->get_local_map()->get_driving_corridor();

--- a/modules/world/world.cpp
+++ b/modules/world/world.cpp
@@ -68,6 +68,7 @@ void World::DoExecution(const float& delta_time) {
   if (remove_agents_) {
     RemoveOutOfMapAgents();
   }
+  RegenerateDrivingCorridors();
 }
 
 WorldPtr World::WorldExecutionAtTime(const float& execution_time) const {
@@ -139,6 +140,19 @@ void World::RemoveOutOfMapAgents() {
     agents_.erase(result_pair.second);
   }
   UpdateAgentRTree();
+}
+
+void World::RegenerateDrivingCorridors() {
+  for (auto &agent : agents_) {
+    map::DrivingCorridor driving_corridor = 
+        agent.second->get_local_map()->get_driving_corridor();
+    geometry::Polygon corridor_polygon = driving_corridor.CorridorPolygon();
+    Point2d position = agent.second->get_current_position();
+
+    if (!geometry::Collide(corridor_polygon, position)) {
+      agent.second->GenerateLocalMap();
+    }
+  }
 }
 
 AgentMap World::GetNearestAgents(const modules::geometry::Point2d& position,

--- a/modules/world/world.hpp
+++ b/modules/world/world.hpp
@@ -98,7 +98,7 @@ class World : public commons::BaseType {
 
   void UpdateAgentRTree();
   void RemoveOutOfMapAgents();
-  void RegenerateDrivingCorridors();
+  void RecalculateDrivingCorridors();
   AgentMap GetNearestAgents(const modules::geometry::Point2d& position,
                             const unsigned int& num_agents) const;
   AgentMap GetAgentsIntersectingPolygon(

--- a/modules/world/world.hpp
+++ b/modules/world/world.hpp
@@ -98,6 +98,7 @@ class World : public commons::BaseType {
 
   void UpdateAgentRTree();
   void RemoveOutOfMapAgents();
+  void RegenerateDrivingCorridors();
   AgentMap GetNearestAgents(const modules::geometry::Point2d& position,
                             const unsigned int& num_agents) const;
   AgentMap GetAgentsIntersectingPolygon(


### PR DESCRIPTION
The behavior model of an agent can cause it to leave its driving corridor, for example when changing lane to overtake an obstacle. In order to still be able to plan a trajectory, the driving corridor of the agent should be updated in this case.

With this pull request, World will attempt to find a new driving corridor for an agent that has moved outside of its old one.
Additionally, it is now also possible to find a driving corridor to a final lane that is parallel to the goal lane, using only successor edges of the roadgraph.