### PR TITLE
Map Import support for Lanes with multiple lane widths

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -12,6 +12,19 @@ py_test(
           "//modules/runtime:runtime",],
 )
 
+py_binary(
+  name = "analyze_map",
+  srcs = ["analyze_map.py"],
+  data = ['//python:bark.so',
+          '//modules/runtime/tests:xodr_data',
+          ':params'],
+  imports = ['../python/'],
+  deps = ["//modules/runtime/commons:parameters",
+          "//modules/runtime/commons:xodr_parser",
+          "//modules/runtime/viewer:matplotlib_viewer",
+          "//modules/runtime:runtime",],
+)
+
 py_test(
   name = "planner_uct_benchmark",
   srcs = ["planner_uct_benchmark.py"],

--- a/examples/analyze_map.py
+++ b/examples/analyze_map.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2019 fortiss GmbH
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+import os
+import unittest
+import time
+import math
+import filecmp
+import matplotlib.pyplot as plt
+from bark.world import World
+from bark.world.map import MapInterface
+from modules.runtime.commons.parameters import ParameterServer
+from modules.runtime.commons.xodr_parser import XodrParser
+from modules.runtime.viewer.matplotlib_viewer import MPViewer
+import numpy as np
+
+# Name and Output Directory
+# CHANGE THIS #
+map_name = "4way_intersection"
+output_dir = "/home/esterle/map_analysis" + map_name
+
+# Map Definition
+xodr_parser = XodrParser("modules/runtime/tests/data/" + map_name + ".xodr")
+
+if not os.path.exists(output_dir):
+    os.makedirs(output_dir)
+
+# World Definition
+params = ParameterServer()
+world = World(params)
+
+map_interface = MapInterface()
+map_interface.set_open_drive_map(xodr_parser.map)
+world.set_map(map_interface)
+
+open_drive_map = world.map.get_open_drive_map()
+
+viewer = MPViewer(params=params, use_world_bounds=True)
+viewer.drawWorld(world)
+viewer.saveFig(output_dir + "/" + "world_plain.png")
+
+color_triplet_gray = (0.7,0.7,0.7)
+
+# Open Drive Elements (Roads, Lane Sections, Lanes)
+for idx_r, road in open_drive_map.get_roads().items():
+  viewer.drawWorld(world)
+  viewer.drawRoad(road)
+  viewer.saveFig(output_dir + "/" + "open_drive_map_road_" + str(idx_r) + ".png")
+  viewer.clear()
+
+for idx_r, road in open_drive_map.get_roads().items():
+  for idx_ls, lane_section in enumerate(road.lane_sections):
+    viewer.drawWorld(world)
+    viewer.drawRoad(road, color_triplet_gray)
+    viewer.drawLaneSection(lane_section)
+    viewer.saveFig(output_dir + "/" + "open_drive_map_road_" + str(idx_r) + "_lane_section" + str(idx_ls) + ".png")
+    viewer.clear()
+
+for idx_r, road in open_drive_map.get_roads().items():
+  for idx_ls, lane_section in enumerate(road.lane_sections):
+    for idx_l, lane in lane_section.get_lanes().items():
+      viewer.drawWorld(world)
+      viewer.drawRoad(road, color_triplet_gray)
+      viewer.drawLaneSection(lane_section, color_triplet_gray)
+      viewer.drawLane(lane)
+      viewer.saveFig(output_dir + "/" + "open_drive_map_road_" + str(idx_r) + "_lane_section" + str(idx_ls) + "_lane" + str(idx_l) + ".png")
+      viewer.clear()
+
+# Lanes of Roadgraph
+roadgraph = map_interface.get_roadgraph()
+roadgraph.print_graph(output_dir + "/" + map_name)
+lane_ids = roadgraph.get_all_laneids ()
+
+for lane_id in lane_ids:
+  lane_polygon = roadgraph.get_lane_polygon_by_id(lane_id)
+  viewer.drawWorld(world)
+  color = list(np.random.choice(range(256), size=3)/256)
+  viewer.drawPolygon2d(lane_polygon, color, 1.0)
+  viewer.saveFig(output_dir + "/" + "roadgraph_laneid_" + str(lane_id) + ".png")
+  viewer.clear()
+
+
+#for rc in all_corridors:
+#    viewer.drawDrivingCorridor(rc)
+#    viewer.saveFig(output_dir + "/" + "test.png")
+
+#map_interface.compute_all_driving_corridors()#
+#
+#all_corridors = map_interface.get_all_corridors()
+# c = all_corridors[10]
+# right_adj_corridors = map_interface.get_adjacent_corridors_same_direction(c, [151, 168, 0.0])
+# assert(len(right_adj_corridors) == 2)
+
+# right_adj_corridors = map_interface.get_adjacent_corridors_same_direction(c, [169, 169, 0.0])
+# assert(len(right_adj_corridors) == 1)

--- a/modules/runtime/commons/xodr_parser.py
+++ b/modules/runtime/commons/xodr_parser.py
@@ -76,6 +76,20 @@ class XodrParser(object):
         new_lane_width["d"] = 0.0
         return new_lane_width
 
+    def parse_lane_widths_from_lane(self, lane, id):
+        lane_width_list = []
+        lane_widths = lane.findall("width")
+            
+        if len(lane_widths) > 0:
+          for lane_width in lane_widths:
+            lane_width = lane_width
+            lane_width_list.append(self.parse_lane_width(lane_width))
+        else:
+          if int(id) == 0:
+            lane_width_list.append(self.zero_lane_width())
+        
+        return lane_width_list
+
     def parse_lanes_from_lane_sections(self, lanes, lane_section):
         # previous or next polynoamial
         lane_dict = {}
@@ -95,16 +109,7 @@ class XodrParser(object):
                 if road_mark: # if dict is not empty
                     new_lane["road_mark"] = road_mark
             
-            new_lane["width"] = []
-            lane_widths = lane.findall("width")
-            
-            if len(lane_widths) > 0:
-              for lane_width in lane_widths:
-                lane_width = lane_width
-                new_lane["width"].append(self.parse_lane_width(lane_width))
-            else:
-              if int(id) == 0:
-                new_lane["width"].append(self.zero_lane_width())
+            new_lane["width"] = self.parse_lane_widths_from_lane(lane, id)
 
             lane_section["lanes"].append(new_lane)
         return lane_section

--- a/modules/runtime/commons/xodr_parser.py
+++ b/modules/runtime/commons/xodr_parser.py
@@ -76,8 +76,7 @@ class XodrParser(object):
         new_lane_width["d"] = 0.0
         return new_lane_width
 
-
-    def parse_lane(self, lanes, lane_section):
+    def parse_lanes_from_lane_sections(self, lanes, lane_section):
         # previous or next polynoamial
         lane_dict = {}
         for lane in lanes:
@@ -95,11 +94,17 @@ class XodrParser(object):
                 road_mark = self.parse_lane_road_mark(lane.find("roadMark"))
                 if road_mark: # if dict is not empty
                     new_lane["road_mark"] = road_mark
-            if lane.find("width") is not None:
-                    new_lane["width"] = self.parse_lane_width(lane.find("width"))
+            
+            new_lane["width"] = []
+            lane_widths = lane.findall("width")
+            
+            if len(lane_widths) > 0:
+              for lane_width in lane_widths:
+                lane_width = lane_width
+                new_lane["width"].append(self.parse_lane_width(lane_width))
             else:
-                if int(id) == 0:
-                    new_lane["width"] = self.zero_lane_width()
+              if int(id) == 0:
+                new_lane["width"].append(self.zero_lane_width())
 
             lane_section["lanes"].append(new_lane)
         return lane_section
@@ -112,7 +117,7 @@ class XodrParser(object):
         new_header["west"] = header.get("west")
         self.python_map["header"] = new_header
 
-    def parse_lane_sections(self, lane_sections, road):
+    def parse_lane_sections_from_road(self, lane_sections, road):
         road["lane_sections"] = []
         for lane_section in lane_sections:
             new_lane_section = {}
@@ -122,7 +127,7 @@ class XodrParser(object):
             for key in lane_keys:
                 if lane_section.find(key) is not None:
                     for lane_group in lane_section.findall(key):
-                        new_lane_section = self.parse_lane(
+                        new_lane_section = self.parse_lanes_from_lane_sections(
                             lane_group.findall('lane'), new_lane_section)
             road["lane_sections"].append(new_lane_section)
         return road
@@ -183,7 +188,7 @@ class XodrParser(object):
         new_road["name"] = road.get("name")
         lanes = road.find("lanes")
         lane_sections = lanes.findall("laneSection")
-        new_road = self.parse_lane_sections(lane_sections, new_road)
+        new_road = self.parse_lane_sections_from_road(lane_sections, new_road)
         new_road = self.parse_plan_view(road.find("planView"), new_road)
         new_road["link"] = self.parse_road_link(road.find("link"))
         self.python_map["roads"].append(new_road)
@@ -305,19 +310,29 @@ class XodrParser(object):
             
         return new_link
 
-    def create_cpp_lane(self, new_lane_section, new_road, lane, s_start,
-                        s_end, reference_line):
+    def create_cpp_lane(self, new_lane_section, new_road, lane, s_end, reference_line):
         try:
-            lane_widths = []
-            a = float(lane["width"]["a"])
-            b = float(lane["width"]["b"])
-            c = float(lane["width"]["c"])
-            d = float(lane["width"]["d"])
-            offset = LaneOffset(a, b, c, d)
-            lane_width = LaneWidth(s_start, s_end, offset)
+            new_lane = Lane(int(lane["id"]))
+            for idx_w, lw in enumerate(lane["width"]):
 
-            # TODO (@hart): make sampling flexible           
-            new_lane = Lane.create_lane_from_lane_width(int(lane["id"]), reference_line, lane_width, 1.0)
+              a = float(lane["width"][idx_w]["a"])
+              b = float(lane["width"][idx_w]["b"])
+              c = float(lane["width"][idx_w]["c"])
+              d = float(lane["width"][idx_w]["d"])
+              offset = LaneOffset(a, b, c, d)
+
+              s_start_temp = float(lane["width"][idx_w]["s_offset"])
+
+              if idx_w < len(lane["width"]) - 1:
+                s_end_temp = float(lane["width"][idx_w+1]["s_offset"])
+              else:
+                # last or only lane width element
+                s_end_temp = s_end
+              
+              lane_width = LaneWidth(s_start_temp, s_end_temp, offset)        
+
+              # TODO (@hart): make sampling flexible           
+              succ = new_lane.append(reference_line, lane_width, 1.0)
 
             new_lane.lane_type = lane["type"]
             
@@ -358,20 +373,20 @@ class XodrParser(object):
                 lane = lane_section["lanes"][idx_iterator]
                 if lane['id'] == 0:
                     # plan view
-                    new_lane_section = self.create_cpp_lane(new_lane_section, new_road, lane, 0.0, float(road["length"]), new_road.plan_view.get_reference_line())
+                    new_lane_section = self.create_cpp_lane(new_lane_section, new_road, lane, float(road["length"]), new_road.plan_view.get_reference_line())
                 elif lane['id'] == -1 or lane['id'] == 1:
                     # use plan view for offset calculation
-                    new_lane_section = self.create_cpp_lane(new_lane_section, new_road, lane, 0.0, float(road["length"]), new_road.plan_view.get_reference_line())
+                    new_lane_section = self.create_cpp_lane(new_lane_section, new_road, lane, float(road["length"]), new_road.plan_view.get_reference_line())
                 else:
                     # use previous line for offset calculation
                     #temp_lanes = new_lane_section.get_lanes()
 
                     if lane['id'] > 0:
                         previous_line = new_lane_section.get_lane_by_position(lane['id']-1).line
-                        new_lane_section = self.create_cpp_lane(new_lane_section, new_road, lane, 0.0, previous_line.length(), previous_line)                                
+                        new_lane_section = self.create_cpp_lane(new_lane_section, new_road, lane, previous_line.length(), previous_line)                                
                     elif lane['id'] < 0:
                         previous_line = new_lane_section.get_lane_by_position(lane['id']+1).line
-                        new_lane_section = self.create_cpp_lane(new_lane_section, new_road, lane, 0.0, previous_line.length(), previous_line)
+                        new_lane_section = self.create_cpp_lane(new_lane_section, new_road, lane, previous_line.length(), previous_line)
                     else:
                         print("Calculating previous lane does not work well.")
 

--- a/modules/runtime/viewer/matplotlib_viewer.py
+++ b/modules/runtime/viewer/matplotlib_viewer.py
@@ -84,6 +84,9 @@ class MPViewer(BaseViewer):
         if filename:
             self.axes.get_figure().savefig(filename)
 
+    def saveFig(self, filename):
+      self.axes.get_figure().savefig(filename)
+
     def show(self, block=False):
         plt.draw()
         if block:

--- a/modules/runtime/viewer/viewer.py
+++ b/modules/runtime/viewer/viewer.py
@@ -188,14 +188,26 @@ class BaseViewer(Viewer):
     def drawMap(self, map):
         # draw the boundary of each lane
         for _, road in map.get_roads().items():
-            for lane_section in road.lane_sections:
-                for _, lane in lane_section.get_lanes().items():
-                    dashed = False
-                    # center line is type none and is drawn as broken
-                    if lane.road_mark.type == RoadMarkType.broken or lane.road_mark.type == RoadMarkType.none: 
-                        dashed = True
-                    self.drawLine2d(lane.line, self.color_lane_boundaries, self.alpha_lane_boundaries, dashed)
+            self.drawRoad(road, self.color_lane_boundaries)
 
+    def drawRoad(self, road, color=None):
+        for lane_section in road.lane_sections:
+          self.drawLaneSection(lane_section, color)
+    
+    def drawLaneSection(self, lane_section, color=None):
+      for _, lane in lane_section.get_lanes().items():
+        self.drawLane(lane, color)
+        
+
+    def drawLane(self, lane, color=None):
+      if color is None:
+        self.color_lane_boundaries
+
+      dashed = False
+      # center line is type none and is drawn as broken
+      if lane.road_mark.type == RoadMarkType.broken or lane.road_mark.type == RoadMarkType.none: 
+        dashed = True
+      self.drawLine2d(lane.line, color, self.alpha_lane_boundaries, dashed)
 
     def drawAgent(self, agent, color):
         shape = agent.shape

--- a/modules/world/opendrive/commons.hpp
+++ b/modules/world/opendrive/commons.hpp
@@ -186,7 +186,8 @@ inline geometry::Line create_line_with_offset_from_line(
   for (; s < lane_width_current_lane.s_end; s += s_inc) {
     geometry::Point2d point = get_point_at_s(previous_line, s);
     normal = get_normal_at_s(previous_line, s);
-    scale = -sign * polynom(s, off.a, off.b, off.c, off.d);
+    // we substract s by s_start, as polynom is defined from [0...<length of lane element>]
+    scale = -sign * polynom(s-lane_width_current_lane.s_start, off.a, off.b, off.c, off.d);
     tmp_line.add_point(
       geometry::Point2d(bg::get<0>(point) + scale * bg::get<0>(normal),
                         bg::get<1>(point) + scale * bg::get<1>(normal)));
@@ -198,7 +199,7 @@ inline geometry::Line create_line_with_offset_from_line(
     geometry::Point2d point =
       get_point_at_s(previous_line, lane_width_current_lane.s_end);
     normal = get_normal_at_s(previous_line, lane_width_current_lane.s_end);
-    scale = -sign * polynom(lane_width_current_lane.s_end, off.a, off.b, off.c, off.d);
+    scale = -sign * polynom(lane_width_current_lane.s_end-lane_width_current_lane.s_start, off.a, off.b, off.c, off.d);
     tmp_line.add_point(
       geometry::Point2d(bg::get<0>(point) + scale * bg::get<0>(normal),
                         bg::get<1>(point) + scale * bg::get<1>(normal)));

--- a/modules/world/opendrive/lane.cpp
+++ b/modules/world/opendrive/lane.cpp
@@ -32,6 +32,13 @@ float Lane::s_from_point(const geometry::Point2d &point) const {
   return 0.0; //modules::geometry::get_nearest_s(this->center_line_, point);
 }
 
+bool Lane::append(geometry::Line previous_line, LaneWidth lane_width_current, float s_inc) {
+  
+  geometry::Line tmp_line = create_line_with_offset_from_line(previous_line, lane_position_, lane_width_current, s_inc);
+  line_.append_linestring(tmp_line);
+  return true;
+}
+
 }  // namespace opendrive
 }  // namespace world
 }  // namespace modules

--- a/modules/world/opendrive/lane.cpp
+++ b/modules/world/opendrive/lane.cpp
@@ -1,8 +1,8 @@
-// Copyright (c) 2019 fortiss GmbH, Julian Bernhard, Klemens Esterle, Patrick Hart, Tobias Kessler
+// Copyright (c) 2019 fortiss GmbH, Julian Bernhard, Klemens Esterle, Patrick
+// Hart, Tobias Kessler
 //
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
-
 
 #include "modules/world/opendrive/lane.hpp"
 
@@ -20,21 +20,18 @@ float Lane::curvature_at(const float s, const float s_delta) const {
   */
   return 0.0;
 }
-float Lane::curvature_dot_at(const float s) const {
-  return 0.0;
-}
+float Lane::curvature_dot_at(const float s) const { return 0.0; }
 
-float Lane::lane_width_at(const float s) const {
-  return 0.0;
-}
+float Lane::lane_width_at(const float s) const { return 0.0; }
 
 float Lane::s_from_point(const geometry::Point2d &point) const {
-  return 0.0; //modules::geometry::get_nearest_s(this->center_line_, point);
+  return 0.0;  // modules::geometry::get_nearest_s(this->center_line_, point);
 }
 
-bool Lane::append(geometry::Line previous_line, LaneWidth lane_width_current, float s_inc) {
-  
-  geometry::Line tmp_line = create_line_with_offset_from_line(previous_line, lane_position_, lane_width_current, s_inc);
+bool Lane::append(geometry::Line previous_line, LaneWidth lane_width_current,
+                  float s_inc) {
+  geometry::Line tmp_line = create_line_with_offset_from_line(
+      previous_line, lane_position_, lane_width_current, s_inc);
   line_.append_linestring(tmp_line);
   return true;
 }

--- a/modules/world/opendrive/lane.hpp
+++ b/modules/world/opendrive/lane.hpp
@@ -1,15 +1,15 @@
-// Copyright (c) 2019 fortiss GmbH, Julian Bernhard, Klemens Esterle, Patrick Hart, Tobias Kessler
+// Copyright (c) 2019 fortiss GmbH, Julian Bernhard, Klemens Esterle, Patrick
+// Hart, Tobias Kessler
 //
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
-
 #ifndef MODULES_WORLD_OPENDRIVE_LANE_HPP_
 #define MODULES_WORLD_OPENDRIVE_LANE_HPP_
 
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 #include "modules/geometry/commons.hpp"
 #include "modules/geometry/line.hpp"
 #include "modules/world/opendrive/commons.hpp"
@@ -18,13 +18,24 @@ namespace modules {
 namespace world {
 namespace opendrive {
 
-
 class Lane {
  public:
-  Lane() : lane_id_(++lane_count), lane_position_(0),
-           link_(), line_(), lane_type_(LaneType::NONE), road_mark_(), speed_() {}
-  explicit Lane(const LanePosition& lane_position) : lane_id_(++lane_count),
-   lane_position_(lane_position), link_(), line_(), lane_type_(LaneType::NONE), road_mark_(), speed_() {}
+  Lane()
+      : lane_id_(++lane_count),
+        lane_position_(0),
+        link_(),
+        line_(),
+        lane_type_(LaneType::NONE),
+        road_mark_(),
+        speed_() {}
+  explicit Lane(const LanePosition& lane_position)
+      : lane_id_(++lane_count),
+        lane_position_(lane_position),
+        link_(),
+        line_(),
+        lane_type_(LaneType::NONE),
+        road_mark_(),
+        speed_() {}
 
   ~Lane() {}
 
@@ -35,10 +46,12 @@ class Lane {
   void set_speed(float speed) { speed_ = speed; }
   void set_lane_type(const LaneType lt) { lane_type_ = lt; }
   void set_road_mark(const RoadMark rm) { road_mark_ = rm; }
-  void set_lane_position(const LanePosition& lane_position)
-                             { lane_position_ = lane_position; }
+  void set_lane_position(const LanePosition& lane_position) {
+    lane_position_ = lane_position;
+  }
 
-  bool append(geometry::Line previous_line, LaneWidth lane_width_current, float s_inc);
+  bool append(geometry::Line previous_line, LaneWidth lane_width_current,
+              float s_inc);
 
   //! getter functions
   geometry::Line get_line() const { return line_; }
@@ -46,15 +59,14 @@ class Lane {
   LaneLink get_link() const { return link_; }
   RoadMark get_road_mark() const { return road_mark_; }
   float get_speed() const { return speed_; }
-  LaneType get_lane_type() const { return lane_type_;}
+  LaneType get_lane_type() const { return lane_type_; }
   LaneId get_id() const { return lane_id_; }
-  LanePosition get_lane_position() const { return lane_position_;}
+  LanePosition get_lane_position() const { return lane_position_; }
 
   float curvature_at(const float s, const float s_delta = 0.01) const;
   float curvature_dot_at(const float s) const;
   float lane_width_at(const float s) const;
-  float s_from_point(const geometry::Point2d &point) const;
-
+  float s_from_point(const geometry::Point2d& point) const;
 
  private:
   LaneId lane_id_;
@@ -69,7 +81,7 @@ class Lane {
   static LaneId lane_count;
 };
 
-inline std::string print(const Lane &l) {
+inline std::string print(const Lane& l) {
   std::stringstream ss;
   ss << "id: " << l.get_id() << ", ";
   ss << "position " << l.get_lane_position() << ", ";
@@ -84,16 +96,16 @@ using LaneSequence = std::vector<LaneId>;
 using LaneSequences = std::vector<LaneSequence>;
 using Lanes = std::map<LaneId, LanePtr>;
 
-
-inline LanePtr create_lane_from_lane_width(LanePosition lane_position, geometry::Line previous_line, LaneWidth lane_width_current, float s_inc = 0.5f) {
-  
+inline LanePtr create_lane_from_lane_width(LanePosition lane_position,
+                                           geometry::Line previous_line,
+                                           LaneWidth lane_width_current,
+                                           float s_inc = 0.5f) {
   std::shared_ptr<Lane> ret_lane(new Lane(lane_position));
 
   bool succ = ret_lane->append(previous_line, lane_width_current, s_inc);
 
   return ret_lane;
 }
-
 
 }  // namespace opendrive
 }  // namespace world

--- a/modules/world/opendrive/lane.hpp
+++ b/modules/world/opendrive/lane.hpp
@@ -38,6 +38,8 @@ class Lane {
   void set_lane_position(const LanePosition& lane_position)
                              { lane_position_ = lane_position; }
 
+  bool append(geometry::Line previous_line, LaneWidth lane_width_current, float s_inc);
+
   //! getter functions
   geometry::Line get_line() const { return line_; }
 
@@ -69,7 +71,8 @@ class Lane {
 
 inline std::string print(const Lane &l) {
   std::stringstream ss;
-  ss << "id: " << l.get_id();
+  ss << "id: " << l.get_id() << ", ";
+  ss << "position " << l.get_lane_position() << ", ";
   ss << print(l.get_link());
   ss << print(l.get_road_mark());
   ss << "speed: " << l.get_speed() << std::endl;
@@ -86,11 +89,11 @@ inline LanePtr create_lane_from_lane_width(LanePosition lane_position, geometry:
   
   std::shared_ptr<Lane> ret_lane(new Lane(lane_position));
 
-  geometry::Line tmp_line = create_line_with_offset_from_line(previous_line, lane_position, lane_width_current, s_inc);
-  ret_lane->set_line(tmp_line);
+  bool succ = ret_lane->append(previous_line, lane_width_current, s_inc);
 
   return ret_lane;
 }
+
 
 }  // namespace opendrive
 }  // namespace world

--- a/modules/world/opendrive/lane_section.hpp
+++ b/modules/world/opendrive/lane_section.hpp
@@ -48,6 +48,14 @@ class LaneSection {
   Lanes lanes_;
 };
 
+inline std::string print(const LaneSection &ls) {
+  std::stringstream ss;
+  ss << "s: " << ls.get_s() << std::endl;
+  for (auto const& l : ls.get_lanes())
+    ss << "Lane: " << print(*(l.second)) << std::endl;
+  return ss.str();
+}
+
 using LaneSectionPtr = std::shared_ptr<LaneSection>;
 
 }  // namespace opendrive

--- a/modules/world/opendrive/lane_section.hpp
+++ b/modules/world/opendrive/lane_section.hpp
@@ -1,40 +1,42 @@
-// Copyright (c) 2019 fortiss GmbH, Julian Bernhard, Klemens Esterle, Patrick Hart, Tobias Kessler
+// Copyright (c) 2019 fortiss GmbH, Julian Bernhard, Klemens Esterle, Patrick
+// Hart, Tobias Kessler
 //
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
-
 #ifndef MODULES_WORLD_OPENDRIVE_LANE_SECTION_HPP_
 #define MODULES_WORLD_OPENDRIVE_LANE_SECTION_HPP_
 
-#include <vector>
 #include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
-#include "modules/world/opendrive/lane.hpp"
 #include "modules/models/dynamic/dynamic_model.hpp"
+#include "modules/world/opendrive/lane.hpp"
 
 namespace modules {
 namespace world {
 namespace opendrive {
-
 
 class LaneSection {
  public:
   explicit LaneSection(float s) : s_(s) {}
   ~LaneSection() {}
 
-  Lanes get_lanes() const {return lanes_;}
+  Lanes get_lanes() const { return lanes_; }
 
   LanePtr get_lane_by_position(LanePosition pos);
 
   LanePtr get_nearest_lane_on_n(double x, double y, double vx, double vy);
-  LanePtr get_lane_with_offset(const models::dynamic::State& state, double angle_offset);
-  
+  LanePtr get_lane_with_offset(const models::dynamic::State& state,
+                               double angle_offset);
+
   LanePtr get_left_lane(const models::dynamic::State& state) {
-    return get_lane_with_offset(state, 3.14/2);
+    return get_lane_with_offset(state, 3.14 / 2);
   }
   LanePtr get_right_lane(const models::dynamic::State& state) {
-    return get_lane_with_offset(state, -3.14/2);
+    return get_lane_with_offset(state, -3.14 / 2);
   }
 
   //! setter functions
@@ -48,7 +50,7 @@ class LaneSection {
   Lanes lanes_;
 };
 
-inline std::string print(const LaneSection &ls) {
+inline std::string print(const LaneSection& ls) {
   std::stringstream ss;
   ss << "s: " << ls.get_s() << std::endl;
   for (auto const& l : ls.get_lanes())

--- a/modules/world/tests/opendrive_test.cc
+++ b/modules/world/tests/opendrive_test.cc
@@ -1,19 +1,19 @@
-// Copyright (c) 2019 fortiss GmbH, Julian Bernhard, Klemens Esterle, Patrick Hart, Tobias Kessler
+// Copyright (c) 2019 fortiss GmbH, Julian Bernhard, Klemens Esterle, Patrick
+// Hart, Tobias Kessler
 //
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
-
 
 #include "gtest/gtest.h"
 
 #include "modules/geometry/commons.hpp"
 #include "modules/geometry/line.hpp"
+#include "modules/world/opendrive/commons.hpp"
+#include "modules/world/opendrive/junction.hpp"
+#include "modules/world/opendrive/lane_section.hpp"
+#include "modules/world/opendrive/opendrive.hpp"
 #include "modules/world/opendrive/plan_view.hpp"
 #include "modules/world/opendrive/road.hpp"
-#include "modules/world/opendrive/lane_section.hpp"
-#include "modules/world/opendrive/junction.hpp"
-#include "modules/world/opendrive/opendrive.hpp"
-#include "modules/world/opendrive/commons.hpp"
 
 TEST(create_plan_view, open_drive) {
   using namespace std;
@@ -32,7 +32,7 @@ TEST(create_plan_view, open_drive) {
   //! add spiral
   p.add_spiral(Point2d(0.0f, 0.0f), 0.0f, 1.0f, 0.0f, 0.7f);
 
-  //p.print_points();
+  // p.print_points();
 }
 
 TEST(lane, open_drive) {
@@ -48,7 +48,8 @@ TEST(lane, open_drive) {
   p.add_line(Point2d(0.0f, 0.0f), 1.5707, 10.0f);
   LaneWidth lane_width = {0, 10.0, off};
 
-  LanePtr lane = create_lane_from_lane_width(1, p.get_reference_line(), lane_width, 0.05f); // left side
+  LanePtr lane = create_lane_from_lane_width(1, p.get_reference_line(),
+                                             lane_width, 0.05f);  // left side
 
   lane->set_lane_type(LaneType::DRIVING);
   EXPECT_EQ(lane->get_lane_type(), LaneType::DRIVING);
@@ -60,10 +61,11 @@ TEST(lane, open_drive) {
   EXPECT_NEAR(bg::get<0>(line.obj_[line.obj_.size() - 1]), -1.5, 0.1);
   EXPECT_NEAR(bg::get<1>(line.obj_[line.obj_.size() - 1]), 10.0, 0.1);
 
-  lane = create_lane_from_lane_width(-1, p.get_reference_line(), lane_width, 0.05f); // right side
+  lane = create_lane_from_lane_width(-1, p.get_reference_line(), lane_width,
+                                     0.05f);  // right side
 
   line = lane->get_line();
-  
+
   std::cout << bg::get<1>(line.obj_[line.obj_.size() - 1]) << std::endl;
 
   EXPECT_NEAR(bg::get<0>(line.obj_[0]), 1.5, 0.1);
@@ -77,7 +79,8 @@ TEST(lane, open_drive) {
   //! horizontal
   p2.add_line(Point2d(0.0f, 0.0f), 0.0f, 10.0f);
 
-  lane = create_lane_from_lane_width(1, p2.get_reference_line(), lane_width, 0.05f); // left side
+  lane = create_lane_from_lane_width(1, p2.get_reference_line(), lane_width,
+                                     0.05f);  // left side
 
   line = lane->get_line();
 
@@ -86,7 +89,8 @@ TEST(lane, open_drive) {
   EXPECT_NEAR(bg::get<0>(line.obj_[line.obj_.size() - 1]), 10.0, 0.1);
   EXPECT_NEAR(bg::get<1>(line.obj_[line.obj_.size() - 1]), 1.5, 0.1);
 
-  lane = create_lane_from_lane_width(-1, p2.get_reference_line(), lane_width, 0.05f); // right side
+  lane = create_lane_from_lane_width(-1, p2.get_reference_line(), lane_width,
+                                     0.05f);  // right side
 
   line = lane->get_line();
   EXPECT_NEAR(bg::get<0>(line.obj_[0]), 0.0, 0.1);
@@ -94,7 +98,8 @@ TEST(lane, open_drive) {
   EXPECT_NEAR(bg::get<0>(line.obj_[line.obj_.size() - 1]), 10.0, 0.1);
   EXPECT_NEAR(bg::get<1>(line.obj_[line.obj_.size() - 1]), -1.5, 0.1);
 
-  // spiral and arc tests are ommitted due to their complexits -> verify with plots!
+  // spiral and arc tests are ommitted due to their complexits -> verify with
+  // plots!
 }
 
 TEST(multiple_lane_widths, open_drive) {
@@ -124,12 +129,11 @@ TEST(multiple_lane_widths, open_drive) {
 
   EXPECT_NEAR(lane_width1.s_end, length1, 0.1);
   EXPECT_NEAR(lane_width2.s_start, length1, 0.1);
-  
+
   EXPECT_NEAR(lane_width2.s_end, length2, 0.1);
 
   EXPECT_TRUE(length1 < length2);
 }
-
 
 TEST(road, open_drive) {
   using namespace std;
@@ -162,8 +166,10 @@ TEST(road, open_drive) {
   //! Lane
   LaneOffset off = {1.0f, 0.0f, 0.0f, 0.0f};
   LaneWidth lane_width = {0, 1, off};
-  LanePtr lane = create_lane_from_lane_width(-1, p->get_reference_line(), lane_width, 0.05f);
-  LanePtr lane2 = create_lane_from_lane_width(1, p->get_reference_line(), lane_width, 0.05f);
+  LanePtr lane = create_lane_from_lane_width(-1, p->get_reference_line(),
+                                             lane_width, 0.05f);
+  LanePtr lane2 = create_lane_from_lane_width(1, p->get_reference_line(),
+                                              lane_width, 0.05f);
 
   ls->add_lane(lane);
   ls2->add_lane(lane2);
@@ -224,10 +230,13 @@ TEST(map, open_drive) {
   LaneOffset off = {1.0f, 0.0f, 0.0f, 0.0f};
   LaneWidth lane_width_1 = {0, 10.0, off};
 
-  LanePtr lane = create_lane_from_lane_width(-1, p->get_reference_line(), lane_width_1, 0.05f);
-  LanePtr lane2 = create_lane_from_lane_width(1, p->get_reference_line(), lane_width_1, 0.05f);
+  LanePtr lane = create_lane_from_lane_width(-1, p->get_reference_line(),
+                                             lane_width_1, 0.05f);
+  LanePtr lane2 = create_lane_from_lane_width(1, p->get_reference_line(),
+                                              lane_width_1, 0.05f);
 
-  RoadMark rm {roadmark::RoadMarkType::SOLID, roadmark::RoadMarkColor::STANDARD, 0.1};
+  RoadMark rm{roadmark::RoadMarkType::SOLID, roadmark::RoadMarkColor::STANDARD,
+              0.1};
 
   std::cout << print(rm) << std::endl;
   lane2->set_road_mark(rm);
@@ -256,8 +265,10 @@ TEST(map, open_drive) {
   LaneOffset off2 = {1.0f, 0.0f, 0.0f, 0.0f};
   LaneWidth lane_width_2 = {0, 10.0, off2};
 
-  LanePtr lane3 = create_lane_from_lane_width(-1, p2->get_reference_line(), lane_width_2, 0.05f);
-  LanePtr lane4 = create_lane_from_lane_width(1, p2->get_reference_line(), lane_width_2, 0.05f);
+  LanePtr lane3 = create_lane_from_lane_width(-1, p2->get_reference_line(),
+                                              lane_width_2, 0.05f);
+  LanePtr lane4 = create_lane_from_lane_width(1, p2->get_reference_line(),
+                                              lane_width_2, 0.05f);
 
   ls3->add_lane(lane3);
   ls3->add_lane(lane4);
@@ -290,8 +301,19 @@ TEST(map, open_drive) {
   // call
   RoadPtr ret_road = map->get_road(100);
   LaneSectionPtr ret_ls = ret_road->get_lane_sections()[0];
-  Lanes ret_lane = ret_ls->get_lanes();
-  auto result = ret_lane.find(7);
+  Lanes ret_lanes = ret_ls->get_lanes();
+  
+  EXPECT_GT(ret_lanes.size(), 0);
+
+  for (auto const& rl : ret_lanes)
+    std::cout << "lane ids are " << rl.first << " , ";
+
+  auto result = ret_lanes.find(8);
+
+  EXPECT_TRUE(result != ret_lanes.end());
+
+  std::cout << "Found lane  " << result->first << " "
+            << print(*(result->second)) << '\n';
   Line ret_line = result->second->get_line();
 
   EXPECT_NEAR(bg::get<0>(ret_line.obj_[0]), 0.0f, 0.1f);
@@ -300,7 +322,7 @@ TEST(map, open_drive) {
   EXPECT_NEAR(bg::get<1>(ret_line.obj_[ret_line.obj_.size() - 1]), -1.0f, 0.1f);
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
 
   return RUN_ALL_TESTS();

--- a/modules/world/tests/opendrive_test.cc
+++ b/modules/world/tests/opendrive_test.cc
@@ -97,6 +97,40 @@ TEST(lane, open_drive) {
   // spiral and arc tests are ommitted due to their complexits -> verify with plots!
 }
 
+TEST(multiple_lane_widths, open_drive) {
+  using namespace modules::world::opendrive;
+  using namespace modules::geometry;
+
+  //! new plan view
+  PlanView p;
+  LaneOffset off1 = {1.5f, 0.0f, 0.0f, 0.0f};
+  LaneOffset off2 = {0.0f, 0.003f, 0.0f, 0.0f};
+
+  LaneWidth lane_width1 = {0, 4.0, off1};
+  LaneWidth lane_width2 = {4.0, 10.0, off2};
+  //! vertical
+  p.add_line(Point2d(0.0f, 0.0f), 1.5707, 10.0f);
+
+  LanePtr lane = std::make_shared<Lane>(1);
+  bool succ = lane->append(p.get_reference_line(), lane_width1, 0.05f);
+
+  Line linel1 = lane->get_line();
+  float length1 = bg::get<1>(linel1.obj_[linel1.obj_.size() - 1]);
+
+  succ = lane->append(p.get_reference_line(), lane_width2, 0.05f);
+
+  Line linel2 = lane->get_line();
+  float length2 = bg::get<1>(linel2.obj_[linel2.obj_.size() - 1]);
+
+  EXPECT_NEAR(lane_width1.s_end, length1, 0.1);
+  EXPECT_NEAR(lane_width2.s_start, length1, 0.1);
+  
+  EXPECT_NEAR(lane_width2.s_end, length2, 0.1);
+
+  EXPECT_TRUE(length1 < length2);
+}
+
+
 TEST(road, open_drive) {
   using namespace std;
   using namespace modules::world::opendrive;

--- a/modules/world/tests/py_opendrive_tests.py
+++ b/modules/world/tests/py_opendrive_tests.py
@@ -4,16 +4,12 @@
 # https://opensource.org/licenses/MIT
 
 import unittest
-# import matplotlib as mpl
-# import matplotlib.pyplot as plt
-from scipy.special import fresnel
 import numpy as np
-# if os.environ.get('DISPLAY','') == '':
-#     print('no display found. Using non-interactive Agg backend')
-#     mpl.use('Agg')
+
+from scipy.special import fresnel
 from bark.world import *
-from bark.world.opendrive import *
-from bark.geometry import *
+from bark.world.opendrive import PlanView, LaneOffset, LaneWidth, Lane, Road, fresnel_cos, fresnel_sin
+from bark.geometry import Point2d
 
 
 class EnvironmentTests(unittest.TestCase):
@@ -32,15 +28,13 @@ class EnvironmentTests(unittest.TestCase):
         offset = LaneOffset(1.5, 0, 0, 0)
         lane_width = LaneWidth(0.0, 59.9, offset)
 
-        lane = Lane.create_lane_from_lane_width(-1, pv.get_reference_line(), lane_width, 0.5)
+        lane = Lane.create_lane_from_lane_width(-1,
+                                                pv.get_reference_line(), lane_width, 0.5)
 
-        #plt.plot(lane.line.toArray()[:, 0], lane.line.toArray()[:, 1])
         print(lane)
-        lane = Lane.create_lane_from_lane_width(1, pv.get_reference_line(), lane_width, 0.5)
+        lane = Lane.create_lane_from_lane_width(
+            1, pv.get_reference_line(), lane_width, 0.5)
         print(lane)
-        #plt.plot(lane.line.toArray()[:, 0], lane.line.toArray()[:, 1])
-        #plt.axis('equal')
-        #plt.show(block=True)
 
     def test_road(self):
         newRoad = Road()
@@ -59,14 +53,11 @@ class EnvironmentTests(unittest.TestCase):
         newRoad.plan_view.add_spiral(p, 1.57079632679, 50.0, 0.0, 0.3, 0.4)
         line = newRoad.plan_view.get_reference_line().toArray()
 
-        #plt.plot(line[:, 0], line[:, 1])
-        #plt.axis('equal')
-        #plt.show(block=True)
-
     def test_spiral(self):
         '''
-		spiral test compares outcome of wrapped odrSpiral implementation with scipy fresnel calculation
-		'''
+        spiral test compares outcome of wrapped odrSpiral implementation with 
+        scipy fresnel calculation
+        '''
 
         # spiral using scipy
         t = np.linspace(-7, 7, 250)
@@ -78,11 +69,6 @@ class EnvironmentTests(unittest.TestCase):
         for t_i in t:
             x_odr.append(fresnel_cos(t_i))
             y_odr.append(fresnel_sin(t_i))
-
-        #plt.plot(x, y)
-        #plt.plot(x_odr, y_odr, 'g')
-        #plt.axes().set_aspect("equal")
-        #plt.show()
 
         x_odr_np = np.asarray(x_odr)
         y_odr_np = np.asarray(y_odr)

--- a/python/world/opendrive.cpp
+++ b/python/world/opendrive.cpp
@@ -84,6 +84,7 @@ void python_opendrive(py::module m) {
       .def_property("line", &Lane::get_line, &Lane::set_line)
       .def_property("road_mark", &Lane::get_road_mark, &Lane::set_road_mark)
       .def_property("speed", &Lane::get_speed, &Lane::set_speed)
+      .def("append", &Lane::append, "Append lane")
       .def("create_lane_from_lane_width", &create_lane_from_lane_width, "Create lane")
       .def(
           "__repr__",
@@ -106,7 +107,15 @@ void python_opendrive(py::module m) {
       .def("get_lanes", &LaneSection::get_lanes, "Get all lane elements")
       .def("get_left_lane", &LaneSection::get_left_lane, "Get left lane")
       .def("get_right_lane", &LaneSection::get_right_lane, "Get right lane")
-      .def("get_lane_by_position", &LaneSection::get_lane_by_position, "Get lane by lane position");
+      .def("get_lane_by_position", &LaneSection::get_lane_by_position, "Get lane by lane position")
+      .def(
+          "__repr__",
+          [](const LaneSection &ls) {
+          std::stringstream ss;
+          ss << "<bark.LaneSection> LaneSection: ";
+          ss << modules::world::opendrive::print(ls);
+          return ss.str();
+      });
 
   py::class_<Road, std::shared_ptr<Road>>(m, "Road")
       .def(py::init<>())


### PR DESCRIPTION
Sometimes, a lane definition may consist of multiple lane widths (often used to implement smooth merging lanes). The Pull Request implements that.

Solves #195 