### PR TITLE
Clone local map when cloning agents

### DIFF
--- a/modules/world/objects/agent.cpp
+++ b/modules/world/objects/agent.cpp
@@ -159,6 +159,9 @@ std::shared_ptr<Object> Agent::Clone() const {
   if (execution_model_) {
     new_agent->execution_model_ = execution_model_->Clone();
   }
+  if(local_map_) {
+    new_agent->local_map_ = LocalMapPtr(local_map_->Clone());
+  }
   return std::dynamic_pointer_cast<Object>(new_agent);
 }
 


### PR DESCRIPTION
The local map also needs to be copied if an agent is cloned, since otherwise the driving corridor in the clone still references the original, which could lead to unwanted side effects.