### PR TITLE
removing incorrect handling of pickle file

### DIFF
--- a/bark/benchmark/benchmark_result.py
+++ b/bark/benchmark/benchmark_result.py
@@ -128,12 +128,16 @@ class BenchmarkResult:
 
     @staticmethod
     def load(filename, load_configs=False, load_histories=False):
-        rst = BenchmarkResult.load_results(filename)
-        if load_configs:
-            rst.load_benchmark_configs()
-        if load_histories:
-            rst.load_histories()
-        return rst
+        if filename.endswith("*.pickle"):
+          logging.warning("pickle files have been depricated")
+          return BenchmarkResult.load_pickle(filename)
+        else:
+          rst = BenchmarkResult.load_results(filename)
+          if load_configs:
+              rst.load_benchmark_configs()
+          if load_histories:
+              rst.load_histories()
+          return rst
 
     def load_histories(self, config_idx_list = None):
         if config_idx_list:

--- a/bark/benchmark/benchmark_result.py
+++ b/bark/benchmark/benchmark_result.py
@@ -128,15 +128,12 @@ class BenchmarkResult:
 
     @staticmethod
     def load(filename, load_configs=False, load_histories=False):
-        if filename.endswith(".pickle"):
-            return BenchmarkResult.load_pickle(filename)
-        else:
-            rst = BenchmarkResult.load_results(filename)
-            if load_configs:
-                rst.load_benchmark_configs()
-            if load_histories:
-                rst.load_histories()
-            return rst
+        rst = BenchmarkResult.load_results(filename)
+        if load_configs:
+            rst.load_benchmark_configs()
+        if load_histories:
+            rst.load_histories()
+        return rst
 
     def load_histories(self, config_idx_list = None):
         if config_idx_list:


### PR DESCRIPTION
saving and loading a pickle file caused the following error:

```dmp = pickle.load(handle)
_pickle.UnpicklingError: A load persistent id instruction was encountered, but no persistent_load function was specified.
```

removing the special handling of pickle files during loading solves this.