### PR TITLE
Scen params desc benchmark

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,7 +28,7 @@ git_repository(
 # -------- Benchmark Database -----------------------
 git_repository(
   name = "benchmark_database",
-  commit="78a248e3a1b272c4c8df0708306cfc05cbf8aab5",
+  commit="ff6e433ecb7878ebe59996f3994ff67483a7c297",
   remote = "https://github.com/bark-simulator/benchmark-database"
 )
 

--- a/bark/benchmark/benchmark_result.py
+++ b/bark/benchmark/benchmark_result.py
@@ -15,6 +15,8 @@ logging.basicConfig()
 logging.getLogger().setLevel(logging.INFO)
 
 
+
+
 class BehaviorConfig:
     def __init__(self, behavior_name, behavior, param_descriptions=None):
         self.behavior_name = behavior_name
@@ -36,24 +38,28 @@ class BehaviorConfig:
 # contains information for a single benchmark run
 class BenchmarkConfig:
     def __init__(self, config_idx, behavior_config,
-                 scenario, scenario_idx, scenario_set_name):
+                 scenario, scenario_idx, scenario_set_name,
+                 scenario_set_param_desc=None):
         self.config_idx = config_idx
         self.behavior_config = behavior_config
         self.scenario = scenario
         self.scenario_idx = scenario_idx
         self.scenario_set_name = scenario_set_name
+        self.scenario_set_param_desc = scenario_set_param_desc or {}
 
     def get_info_string_list(self):
         info_strings = ["ConfigIdx: {}".format(self.config_idx),
                         "Behavior: {}".format(self.behavior_config.behavior_name),
                         "ScenarioSet: {}".format(self.scenario_set_name),
-                        "ScenarioIdx: {}".format(self.scenario_idx)]
+                        "ScenarioIdx: {}".format(self.scenario_idx),
+                        "ScenarioParamDes: {}".format(self.scenario_set_param_desc)]
         return info_strings
 
     def as_dict(self):
         return {"config_idx": self.config_idx,
                 "scen_set": self.scenario_set_name,
                 "scen_idx": self.scenario_idx,
+                **self.scenario_set_param_desc,
                 **self.behavior_config.as_dict()}
 
     def get_evaluation_groups(self):

--- a/bark/benchmark/benchmark_runner.py
+++ b/bark/benchmark/benchmark_runner.py
@@ -114,7 +114,7 @@ class BenchmarkRunner:
         benchmark_configs = []
         for behavior_config in self.behavior_configs:
             # run over all scenario generators from benchmark database
-            for scenario_generator, scenario_set_name in self.benchmark_database:
+            for scenario_generator, scenario_set_name, scenario_set_param_desc in self.benchmark_database:
                 for scenario, scenario_idx in scenario_generator:
                     if num_scenarios and scenario_idx >= num_scenarios:
                         break
@@ -124,7 +124,8 @@ class BenchmarkRunner:
                             behavior_config,
                             scenario,
                             scenario_idx,
-                            scenario_set_name
+                            scenario_set_name,
+                            scenario_set_param_desc
                         )
                     benchmark_configs.append(benchmark_config)
         return benchmark_configs

--- a/bark/benchmark/tests/py_benchmark_process_tests.py
+++ b/bark/benchmark/tests/py_benchmark_process_tests.py
@@ -11,8 +11,10 @@ import os
 import ray
 
 try:
-    import tools.debug_settings
+    debug = True
+    import debug_settings
 except:
+    debug = False
     pass
 
 import matplotlib.pyplot as plt
@@ -37,7 +39,10 @@ class DatabaseRunnerTests(unittest.TestCase):
         dbs = DatabaseSerializer(test_scenarios=2, test_world_steps=3, num_serialize_scenarios=2)
         # to find database files
         cwd = os.getcwd()
-        os.chdir("../benchmark_database/")
+        if not debug:
+          os.chdir("../benchmark_database/")
+        else:
+          os.chdir("bazel-bin/bark/benchmark/tests/py_benchmark_process_tests.runfiles/benchmark_database")
         dbs.process("data/database1")
         local_release_filename = dbs.release(version="test")
 

--- a/bark/runtime/scenario/scenario_generation/configurable_scenario_generation.py
+++ b/bark/runtime/scenario/scenario_generation/configurable_scenario_generation.py
@@ -79,8 +79,9 @@ class ConfigurableScenarioGeneration(ScenarioGeneration):
     self._sink_source_default_params = None
 
   def update_defaults_params(self):
-    self._params["Scenario"]["Generation"]["ConfigurableScenarioGeneration"]["SinksSources"] = \
-        self._sink_source_default_params
+    pass
+    #  self._params["Scenario"]["Generation"]["ConfigurableScenarioGeneration"]["SinksSources"] = \
+     #     self._sink_source_default_params
 
   def add_config_reader_parameter_servers(self, description, config_type, config_reader):
     self._sink_source_parameter_servers[config_type].append(
@@ -132,8 +133,8 @@ class ConfigurableScenarioGeneration(ScenarioGeneration):
       kwargs_agent_states_geometry.append(kwargs_dict)
 
       # collect default parameters of this config
-      sink_source_default_params.append(sink_source_config)
-      sink_source_default_params[idx]["ConfigAgentStatesGeometries"] = default_params_state_geometry.ConvertToDict()
+      #sink_source_default_params.append(sink_source_config)
+      #sink_source_default_params[idx]["ConfigAgentStatesGeometries"] = default_params_state_geometry.ConvertToDict()
       collected_sources_sinks_agent_states_geometries.append((agent_states, agent_geometries))
 
     #2 remove overlapping agent states from different sources and sinks
@@ -160,7 +161,7 @@ class ConfigurableScenarioGeneration(ScenarioGeneration):
                               sink_source_config, "ConfigBehaviorModels", 
                               args_list, kwargs_dict)
       behavior_models = config_return
-      sink_source_default_params[idx]["ConfigBehaviorModels"] = default_params_behavior.ConvertToDict()
+      #sink_source_default_params[idx]["ConfigBehaviorModels"] = default_params_behavior.ConvertToDict()
       
       kwargs_dict = {**kwargs_dict, **kwargs_dict_tmp}
       config_return, kwargs_dict_tmp, default_params_execution = \
@@ -168,7 +169,7 @@ class ConfigurableScenarioGeneration(ScenarioGeneration):
                               sink_source_config, "ConfigExecutionModels",
                               args_list, kwargs_dict)
       execution_models = config_return
-      sink_source_default_params[idx]["ConfigExecutionModels"] = default_params_execution.ConvertToDict()
+      #sink_source_default_params[idx]["ConfigExecutionModels"] = default_params_execution.ConvertToDict()
       kwargs_dict = {**kwargs_dict, **kwargs_dict_tmp}
 
 
@@ -177,7 +178,7 @@ class ConfigurableScenarioGeneration(ScenarioGeneration):
                               sink_source_config, "ConfigDynamicModels",
                               args_list, kwargs_dict)
       dynamic_models = config_return
-      sink_source_default_params[idx]["ConfigDynamicModels"] = default_params_dynamic.ConvertToDict()
+      #sink_source_default_params[idx]["ConfigDynamicModels"] = default_params_dynamic.ConvertToDict()
       kwargs_dict = {**kwargs_dict, **kwargs_dict_tmp}
 
       #4 create goal definitions and controlled agents
@@ -187,7 +188,7 @@ class ConfigurableScenarioGeneration(ScenarioGeneration):
                               args_list, kwargs_dict)
       controlled_agent_ids = config_return
       controlled_agent_ids_all.extend(controlled_agent_ids)
-      sink_source_default_params[idx]["ConfigControlledAgents"] = default_params_controlled_agents.ConvertToDict()
+      #sink_source_default_params[idx]["ConfigControlledAgents"] = default_params_controlled_agents.ConvertToDict()
       kwargs_dict = {**kwargs_dict, **kwargs_dict_tmp}
 
       args_list = [*args_list, controlled_agent_ids]
@@ -196,22 +197,22 @@ class ConfigurableScenarioGeneration(ScenarioGeneration):
                               sink_source_config, "ConfigGoalDefinitions", 
                               args_list, kwargs_dict)
       goal_definitions = config_return
-      sink_source_default_params[idx]["ConfigGoalDefinitions"] = default_params_goals.ConvertToDict()
+      #sink_source_default_params[idx]["ConfigGoalDefinitions"] = default_params_goals.ConvertToDict()
 
       #5 Build all agents for this source config
       kwargs_dict = {**kwargs_dict, **kwargs_dict_tmp}
-      agent_params = ParameterServer(json = sink_source_config["AgentParams"])
+      agent_params = sink_source_config["AgentParams"]
       sink_source_agents, controlled_ids = self.create_source_config_agents(agent_states,
                       agent_geometries, behavior_models, execution_models,
                       dynamic_models, goal_definitions, controlled_agent_ids,
                       world, agent_params)
-      sink_source_default_params[idx]["AgentParams"] = agent_params.ConvertToDict()
+      #sink_source_default_params[idx]["AgentParams"] = agent_params.ConvertToDict()
 
       self.update_road_corridors(sink_source_agents, road_corridor)
       agent_list.extend(sink_source_agents)
-      collected_sources_sinks_default_param_configs.append(sink_source_config)
+      #collected_sources_sinks_default_param_configs.append(sink_source_config)
 
-    self._sink_source_default_params = sink_source_default_params
+    #self._sink_source_default_params = sink_source_default_params
     scenario._eval_agent_ids = controlled_ids
     scenario._agent_list = agent_list
     
@@ -436,7 +437,6 @@ class ConfigurableScenarioGeneration(ScenarioGeneration):
   def eval_configuration(self, sink_source_config, config_type, args, kwargs):
     eval_config = sink_source_config[config_type]
     eval_config_type = eval_config["Type"]
-    param_config = ParameterServer(json = eval_config, log_if_default = self._params.log_if_default)
     try:
       config_reader = eval("{}(self._random_state, self._current_scenario_idx)".format(eval_config_type))
     except NameError as error:
@@ -448,7 +448,7 @@ class ConfigurableScenarioGeneration(ScenarioGeneration):
             pass
         if not config_reader:
           raise ValueError("Config reader type {} not found in added module paths".format(eval_config_type))
-    config_return  = config_reader.create_from_config(param_config, *args, **kwargs)
+    config_return  = config_reader.create_from_config(eval_config, *args, **kwargs)
     self.add_config_reader_parameter_servers(sink_source_config["Description"], config_type, config_reader)
     return config_return
 

--- a/bark/runtime/scenario/scenario_generation/deterministic.py
+++ b/bark/runtime/scenario/scenario_generation/deterministic.py
@@ -58,7 +58,7 @@ class DeterministicScenarioGeneration(ScenarioGeneration):
     agent_list = []
     scenario._agent_list = []
     for agent_json_ in self._local_params["Agents"]:
-      agent_json = agent_json_["VehicleModel"].copy()
+      agent_json = agent_json_["VehicleModel"].clone()
       agent_json["map_interface"] = world.map
       goal_polygon = Polygon2d([0, 0, 0],
                                np.array(agent_json["goal"]["polygon_points"]))

--- a/bark/runtime/tests/BUILD
+++ b/bark/runtime/tests/BUILD
@@ -58,7 +58,9 @@ py_test(
   name = "py_param_server_tests",
   srcs = ["py_param_server_tests.py"],
   data = ['//bark:generate_core'],
-  deps = ["//bark/runtime/commons:commons" ]
+  deps = [
+          "//bark/runtime/commons:commons",
+          "//tools/debug:debug_settings" ]
 )
 
 py_test(

--- a/bark/runtime/tests/py_param_server_tests.py
+++ b/bark/runtime/tests/py_param_server_tests.py
@@ -6,6 +6,11 @@
 # This work is licensed under the terms of the MIT license.
 # For a copy, see <https://opensource.org/licenses/MIT>.
 
+try:
+    import debug_settings
+except:
+    pass
+
 import unittest
 import pickle
 import numpy as np
@@ -57,6 +62,49 @@ class ParamServerTests(unittest.TestCase):
     self.assertEqual(len(list3), len(list4))
     for idx, _ in enumerate(list3):
         self.assertAlmostEqual(list3[idx], list4[idx], places=5)
+
+  def test_set_item_using_delimiter(self):
+    params = ParameterServer()
+    _ = params["test_child"]["Child2"]["ValueFloat", "Desc", 2.0]
+    params["test_child::Child2::ValueFloat"] = 3.2323
+    self.assertEqual(params["test_child"]["Child2"]["ValueFloat"], 3.2323)
+
+    child = params.AddChild("test_child5::Child5")
+    child["test_param2"] = "etesd99533sbgfgf"
+    self.assertEqual(params["test_child5"]["Child5"]["test_param2", "Desc", 0], "etesd99533sbgfgf")
+
+  def test_set_item_param_server_list_included_in_hierarchy(self):
+    params = ParameterServer()
+    params["test_child"]["Child2"]["ListOfParamServers"] = [{
+      "ListEl1Param1" : 1.0,
+      "ListEl1Param2" : 5,
+      "ListEl1Child1" : {
+        "ListEl1Child1Param1" : "dfdfdfasdgdfhdfg",
+        "ListEl1Child1Param2" : 4343,
+        
+      },
+      "EqualNameParams": {
+        "EqualNameParam1": 20.03434,
+        "EqualNameParam2": 2167767545
+      }
+    },
+    {
+      "ListEl2Param1" : 2.0,
+      "ListEl2Param2" : 232,
+      "EqualNameParams": {
+        "EqualNameParam1": 20.03434,
+        "EqualNameParam2": 2123232
+      }
+    }]
+
+    self.assertEqual(params["test_child"]["Child2"]["ListOfParamServers"][0]["ListEl1Param2"], 5)
+    self.assertTrue(isinstance(params["test_child"]["Child2"]["ListOfParamServers"][0], ParameterServer))
+    self.assertEqual(params["test_child"]["Child2"]["ListOfParamServers"][1]["ListEl2Param1"], 2.0)
+    self.assertEqual(params["test_child"]["Child2"]["ListOfParamServers"][0]["ListEl1Child1"]["ListEl1Child1Param1"], "dfdfdfasdgdfhdfg")
+
+    params["test_child::Child2::ListOfParamServers::EqualNameParams::EqualNameParam1"] = 4545.232566
+    self.assertEqual(params["test_child"]["Child2"]["ListOfParamServers"][0]["EqualNameParams"]["EqualNameParam1"], 4545.232566)
+    self.assertEqual(params["test_child"]["Child2"]["ListOfParamServers"][1]["EqualNameParams"]["EqualNameParam1"], 4545.232566)
 
   def test_key_not_found(self):
     params = ParameterServer(log_if_default=True)


### PR DESCRIPTION
- Scenario set parameters can have an additional optional param description dict
- this dict is maintained during benchmarking
- allows understandable testing of parameter variations in benchmarks without having to name scenario set names appropriately

- ParamServer supports now list of ParameterServers as Parameter (already used in ConfigurableScenarioGeneration, but only handled there not in a perfect way)
- ParamServer supports item setting via delimiter hierarchy, e.g. params["child1::child2::child3::param1"] = 1
- If in parameter hierarchy a list of ParameterServers occurs, on parameter server in the list can be changed with e.g. params["child1"][0]["child2"] = 1 or if equal params occur in the lists all params can be set at once with ["child1::child2"] = 1