### PR TITLE
fix bug in base_idm if lane corridors are not same

### DIFF
--- a/bark/geometry/standard_shapes.cpp
+++ b/bark/geometry/standard_shapes.cpp
@@ -26,7 +26,7 @@ Polygon bark::geometry::standard_shapes::CarLimousine() {
 
 Polygon bark::geometry::standard_shapes::CarRectangle() {
   return Polygon(
-      Pose(1.25, 1, 0),
+      Pose(1.25, 0, 0),
       std::vector<Point2d>{Point2d(-1, -1), Point2d(-1, 1), Point2d(3, 1),
                            Point2d(3, -1), Point2d(-1, -1)});
 }

--- a/bark/models/behavior/idm/base_idm.cpp
+++ b/bark/models/behavior/idm/base_idm.cpp
@@ -106,8 +106,9 @@ double BaseIDM::CalcInteractionTerm(double net_distance, double vel_ego,
 }
 
 double BaseIDM::CalcNetDistance(
-    const std::shared_ptr<const Agent>& ego_agent,
+    const world::ObservedWorld& observed_world,
     const std::shared_ptr<const Agent>& leading_agent) const {
+  const auto& ego_agent = observed_world.GetEgoAgent();
   // relative velocity and longitudinal distance
   const State ego_state = ego_agent->GetCurrentState();
   FrenetPosition frenet_ego = ego_agent->CurrentFrenetPosition();
@@ -119,9 +120,7 @@ double BaseIDM::CalcNetDistance(
 
   // we need to use the lane corridor of the ego agent to be able to compare the
   // frenet values
-  const auto& lane_corridor =
-      ego_agent->GetRoadCorridor()->GetCurrentLaneCorridor(
-          ego_agent->GetCurrentPosition());
+  const auto& lane_corridor = observed_world.GetLaneCorridor();
   FrenetPosition frenet_leading(leading_agent->GetCurrentPosition(),
                                 lane_corridor->GetCenterLine());
 
@@ -179,11 +178,10 @@ IDMRelativeValues BaseIDM::CalcRelativeValues(
 
   std::pair<AgentPtr, FrenetPosition> leading_vehicle =
       observed_world.GetAgentInFront(lane_corr);
-  std::shared_ptr<const Agent> ego_agent = observed_world.GetEgoAgent();
 
   // vehicles
   if (leading_vehicle.first) {
-    leading_distance = CalcNetDistance(ego_agent, leading_vehicle.first);
+    leading_distance = CalcNetDistance(observed_world, leading_vehicle.first);
     dynamic::State other_vehicle_state =
         leading_vehicle.first->GetCurrentState();
     leading_velocity = other_vehicle_state(StateDefinition::VEL_POSITION);

--- a/bark/models/behavior/idm/base_idm.cpp
+++ b/bark/models/behavior/idm/base_idm.cpp
@@ -117,7 +117,14 @@ double BaseIDM::CalcNetDistance(
   const State leading_state = leading_agent->GetCurrentState();
   const float other_velocity = leading_state(StateDefinition::VEL_POSITION);
 
-  FrenetPosition frenet_leading = leading_agent->CurrentFrenetPosition();
+  // we need to use the lane corridor of the ego agent to be able to compare the
+  // frenet values
+  const auto& lane_corridor =
+      ego_agent->GetRoadCorridor()->GetCurrentLaneCorridor(
+          ego_agent->GetCurrentPosition());
+  FrenetPosition frenet_leading(leading_agent->GetCurrentPosition(),
+                                lane_corridor->GetCenterLine());
+
   const float vehicle_length =
       ego_agent->GetShape().front_dist_ + leading_agent->GetShape().rear_dist_;
   const double net_distance =

--- a/bark/models/behavior/idm/base_idm.hpp
+++ b/bark/models/behavior/idm/base_idm.hpp
@@ -51,7 +51,7 @@ class BaseIDM : virtual public BehaviorModel {
   double CalcInteractionTerm(const double net_distance, const double vel_ego,
                              const double vel_other) const;
   double CalcNetDistance(
-      const std::shared_ptr<const world::objects::Agent>& ego_agent,
+      const world::ObservedWorld& observed_world,
       const std::shared_ptr<const world::objects::Agent>& leading_agent) const;
 
   std::pair<bool, double> GetDistanceToLaneEnding(

--- a/bark/models/tests/behavior_idm_classic_test.cc
+++ b/bark/models/tests/behavior_idm_classic_test.cc
@@ -46,7 +46,8 @@ class DummyBehaviorIDM : public BehaviorIDMClassic {
 
     double acc;
     if (leading_vehicle.first) {
-      double net_distance = CalcNetDistance(ego_agent, leading_vehicle.first);
+      double net_distance =
+          CalcNetDistance(observed_world, leading_vehicle.first);
       State other_vehicle_state = leading_vehicle.first->GetCurrentState();
       double vel_other = other_vehicle_state(StateDefinition::VEL_POSITION);
       acc = CalcIDMAcc(net_distance, vel_i, vel_other);
@@ -72,7 +73,7 @@ TEST(free_road_term, behavior_idm_classic) {
 
   // Create an observed world with specific goal definition and the
   // corresponding mcts state
-  Polygon polygon = GenerateGoalRectangle(6,3);
+  Polygon polygon = GenerateGoalRectangle(6, 3);
   std::shared_ptr<Polygon> goal_polygon(
       std::dynamic_pointer_cast<Polygon>(polygon.Translate(
           Point2d(50, -2))));  // < move the goal polygon into the driving
@@ -127,7 +128,7 @@ TEST(interaction_term, behavior_idm_classic) {
 
   // Create an observed world with specific goal definition and the
   // corresponding mcts state
-  Polygon polygon = GenerateGoalRectangle(6,3);
+  Polygon polygon = GenerateGoalRectangle(6, 3);
   std::shared_ptr<Polygon> goal_polygon(
       std::dynamic_pointer_cast<Polygon>(polygon.Translate(
           Point2d(50, -2))));  // < move the goal polygon into the driving
@@ -222,7 +223,7 @@ TEST(drive_leading_vehicle, behavior_idm_classic) {
 
   // Create an observed world with specific goal definition and the
   // corresponding mcts state
-  Polygon polygon = GenerateGoalRectangle(6,3);
+  Polygon polygon = GenerateGoalRectangle(6, 3);
   std::shared_ptr<Polygon> goal_polygon(
       std::dynamic_pointer_cast<Polygon>(polygon.Translate(
           Point2d(50, -2))));  // < move the goal polygon into the driving
@@ -282,7 +283,7 @@ TEST(coolness_factor_upper_eq_case, behavior_idm_classic) {
 
   // Create an observed world with specific goal definition and the
   // corresponding mcts state
-  Polygon polygon = GenerateGoalRectangle(6,3);
+  Polygon polygon = GenerateGoalRectangle(6, 3);
   std::shared_ptr<Polygon> goal_polygon(
       std::dynamic_pointer_cast<Polygon>(polygon.Translate(
           Point2d(50, -2))));  // < move the goal polygon into the driving
@@ -343,7 +344,7 @@ TEST(coolness_factor_lower_eq_case_vel_diff_neg, behavior_idm_classic) {
   float time_step = 0.2f;  // Very small time steps to verify differential
                            // integration character
 
-  Polygon polygon = GenerateGoalRectangle(6,3);
+  Polygon polygon = GenerateGoalRectangle(6, 3);
   std::shared_ptr<Polygon> goal_polygon(
       std::dynamic_pointer_cast<Polygon>(polygon.Translate(
           Point2d(50, -2))));  // < move the goal polygon into the driving
@@ -401,7 +402,7 @@ TEST(coolness_factor_lower_eq_case_vel_diff_pos, behavior_idm_classic) {
 
   // Create an observed world with specific goal definition and the
   // corresponding mcts state
-  Polygon polygon = GenerateGoalRectangle(6,3);
+  Polygon polygon = GenerateGoalRectangle(6, 3);
   std::shared_ptr<Polygon> goal_polygon(
       std::dynamic_pointer_cast<Polygon>(polygon.Translate(
           Point2d(50, -2))));  // < move the goal polygon into the driving
@@ -462,8 +463,20 @@ TEST(CalcNetDistance, behavior_idm_classic) {
                             params, goal_definition_ptr, map_interface,
                             bark::geometry::Model3D()));
 
+  WorldPtr world(new World(params));
+  world->AddAgent(agent1);
+  world->AddAgent(agent2);
+  world->UpdateAgentRTree();
+
+  world->SetMap(map_interface);
+
+  auto current_world_state = WorldPtr(world->Clone());
+  ObservedWorld observed_world(
+      current_world_state,
+      current_world_state->GetAgents().begin()->second->GetAgentId());
+
   BehaviorIDMClassic behavior(params);
-  float distance = behavior.CalcNetDistance(agent1, agent2);
+  float distance = behavior.CalcNetDistance(observed_world, agent2);
   float x_diff = init_state2(StateDefinition::X_POSITION) -
                  init_state1(StateDefinition::X_POSITION);
   float distance_expected =


### PR DESCRIPTION
- solves the issue that when of the distance calculation in idm_base `behavior.CalcNetDistance(agent1, agent2);` +
when agent2 has a different lane corridor than agent 1 (for example because it is on a successor road)
- previously, the frenet coordinates in this distance calculation where not comparable
- strange behavior occured for example in the merging scenario to the followint agent, if the leader was placed on the road after the merging point
- I added a unit test to show the bug