### PR TITLE
Evaluator capture states

### DIFF
--- a/bark/python_wrapper/world/evaluation.cpp
+++ b/bark/python_wrapper/world/evaluation.cpp
@@ -78,11 +78,11 @@ void python_evaluation(py::module m) {
       .def("__repr__", [](const EvaluatorStepCount& g) {
         return "bark.core.world.evaluation.EvaluatorStepCount";
       });
-  py::class_<EvaluatorCaptureStates, BaseEvaluator,
-             std::shared_ptr<EvaluatorCaptureStates>>(m, "EvaluatorCaptureStates")
+  py::class_<EvaluatorCaptureAgentStates, BaseEvaluator,
+             std::shared_ptr<EvaluatorCaptureAgentStates>>(m, "EvaluatorCaptureAgentStates")
       .def(py::init<>())
-      .def("__repr__", [](const EvaluatorCaptureStates& g) {
-        return "bark.core.world.evaluation.EvaluatorCaptureStates";
+      .def("__repr__", [](const EvaluatorCaptureAgentStates& g) {
+        return "bark.core.world.evaluation.EvaluatorCaptureAgentStates";
       });
   
   python_ltl(m.def_submodule("ltl", "LTL Rules"));

--- a/bark/python_wrapper/world/evaluation.cpp
+++ b/bark/python_wrapper/world/evaluation.cpp
@@ -13,6 +13,7 @@
 #include "bark/world/evaluation/evaluator_drivable_area.hpp"
 #include "bark/world/evaluation/evaluator_goal_reached.hpp"
 #include "bark/world/evaluation/evaluator_step_count.hpp"
+#include "bark/world/evaluation/evaluator_capture_states.hpp"
 #include "bark/world/world.hpp"
 
 #include "bark/python_wrapper/world/ltl.hpp"
@@ -77,6 +78,12 @@ void python_evaluation(py::module m) {
       .def("__repr__", [](const EvaluatorStepCount& g) {
         return "bark.core.world.evaluation.EvaluatorStepCount";
       });
-
+  py::class_<EvaluatorCaptureStates, BaseEvaluator,
+             std::shared_ptr<EvaluatorCaptureStates>>(m, "EvaluatorCaptureStates")
+      .def(py::init<>())
+      .def("__repr__", [](const EvaluatorCaptureStates& g) {
+        return "bark.core.world.evaluation.EvaluatorCaptureStates";
+      });
+  
   python_ltl(m.def_submodule("ltl", "LTL Rules"));
 }

--- a/bark/world/evaluation/BUILD
+++ b/bark/world/evaluation/BUILD
@@ -109,6 +109,20 @@ cc_library(
 )
 
 cc_library(
+    name = "evaluator_capture_states",
+    hdrs = [
+        "evaluator_capture_states.hpp"
+    ],
+    deps = [
+        "//bark/world/evaluation:base_evaluator",
+        "//bark/world:world",
+        "//bark/models/dynamic:dynamic",
+        "//bark/commons:commons"
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "evaluator_drivable_area",
     hdrs = [
         "evaluator_drivable_area.hpp"
@@ -134,6 +148,7 @@ cc_library(
         ":evaluator_step_count",
         ":evaluator_behavior_expired",
         ":evaluator_distance_to_goal",
+        ":evaluator_capture_states",
         "//bark/world/evaluation/ltl:evaluator_ltl",
     ],
     visibility = ["//visibility:public"],

--- a/bark/world/evaluation/base_evaluator.hpp
+++ b/bark/world/evaluation/base_evaluator.hpp
@@ -12,6 +12,7 @@
 #include <boost/variant.hpp>
 #include <memory>
 #include <string>
+#include <map>
 #include "bark/commons/commons.hpp"
 #include "bark/models/dynamic/dynamic_model.hpp"
 

--- a/bark/world/evaluation/base_evaluator.hpp
+++ b/bark/world/evaluation/base_evaluator.hpp
@@ -11,7 +11,9 @@
 
 #include <boost/variant.hpp>
 #include <memory>
+#include <string>
 #include "bark/commons/commons.hpp"
+#include "bark/models/dynamic/dynamic_model.hpp"
 
 namespace bark {
 namespace world {
@@ -19,7 +21,8 @@ class World;
 class ObservedWorld;
 namespace evaluation {
 
-typedef boost::variant<float, bool, std::string, int> EvaluationReturn;
+using models::dynamic::State;
+typedef boost::variant<float, bool, std::string, int, std::map<std::string, State>> EvaluationReturn;
 
 class BaseEvaluator {
  public:

--- a/bark/world/evaluation/evaluator_capture_states.hpp
+++ b/bark/world/evaluation/evaluator_capture_states.hpp
@@ -22,10 +22,10 @@ class World;
 class ObservedWorld;
 namespace evaluation {
 
-class EvaluatorCaptureStates : public BaseEvaluator {
+class EvaluatorCaptureAgentStates : public BaseEvaluator {
  public:
-  EvaluatorCaptureStates() {}
-  virtual ~EvaluatorCaptureStates() {}
+  EvaluatorCaptureAgentStates() {}
+  virtual ~EvaluatorCaptureAgentStates() {}
 
   EvaluationReturn Evaluate(const world::World& world) {
     std::map<std::string, State> states;

--- a/bark/world/evaluation/evaluator_capture_states.hpp
+++ b/bark/world/evaluation/evaluator_capture_states.hpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2020 fortiss GmbH
+//
+// Authors: Julian Bernhard, Klemens Esterle, Patrick Hart and
+// Tobias Kessler
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#ifndef BARK_WORLD_EVALUATION_EVALUATOR_CAPTURE_STATES_HPP_
+#define BARK_WORLD_EVALUATION_EVALUATOR_CAPTURE_STATES_HPP_
+
+#include <memory>
+
+#include "bark/world/evaluation/base_evaluator.hpp"
+#include "bark/world/observed_world.hpp"
+
+
+namespace bark {
+namespace world {
+
+class World;
+class ObservedWorld;
+namespace evaluation {
+
+class EvaluatorCaptureStates : public BaseEvaluator {
+ public:
+  EvaluatorCaptureStates() {}
+  virtual ~EvaluatorCaptureStates() {}
+
+  EvaluationReturn Evaluate(const world::World& world) {
+    std::map<std::string, State> states;
+    for (const auto& agent : world.GetAgents()) {
+      std::string idx = "state_" + std::to_string(agent.first);
+      states[idx] = agent.second->GetCurrentState();
+    }
+    return states;
+  }
+
+  EvaluationReturn Evaluate(const world::ObservedWorld& world) {
+    std::map<std::string, State> states;
+    for (const auto& agent : world.GetAgents()) {
+      std::string idx = "state_" + std::to_string(agent.first);
+      states[idx] = agent.second->GetCurrentState();
+    }
+    return states;
+  }
+};
+
+}  // namespace evaluation
+}  // namespace world
+}  // namespace bark
+
+#endif  // BARK_WORLD_EVALUATION_EVALUATOR_CAPTURE_STATES_HPP_

--- a/bark/world/tests/evaluation/BUILD
+++ b/bark/world/tests/evaluation/BUILD
@@ -31,3 +31,14 @@ py_test(
         "//bark/runtime/scenario/scenario_generation",
     ],
 )
+
+cc_test(
+    name = "capture_states_test",
+    srcs = ["capture_states_test.cc"],
+    copts = ["-Iexternal/gtest/include"],
+    deps = [
+        "@gtest//:gtest_main",
+        "//bark/world/tests:make_test_world",
+        "//bark/world/evaluation:evaluation",
+    ],
+)

--- a/bark/world/tests/evaluation/capture_states_test.cc
+++ b/bark/world/tests/evaluation/capture_states_test.cc
@@ -1,0 +1,40 @@
+// Copyright (c) 2020 fortiss GmbH
+//
+// Authors: Julian Bernhard, Klemens Esterle, Patrick Hart and
+// Tobias Kessler
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "gtest/gtest.h"
+
+#include "bark/world/evaluation/evaluator_capture_states.hpp"
+#include "bark/commons/params/setter_params.hpp"
+#include "bark/world/tests/make_test_world.hpp"
+
+using namespace bark::world::evaluation;
+using namespace bark::world::tests;
+using bark::commons::SetterParams;
+
+TEST(capture_test, base_functionality) {
+  auto world = make_test_world(1, 5.0, 20.0, 0.0);
+  // auto observed_worlds = world->Observe({1});
+  auto eval_capture_states = std::make_shared<EvaluatorCaptureStates>();
+  world->AddEvaluator("capture_states", eval_capture_states);
+  auto eval_res = world->Evaluate();
+
+  auto casted_res = boost::get<std::map<std::string, State>>(
+    eval_res["capture_states"]);
+  // NOTE: assert size is 2
+  // NOTE: assert state_1 and state_2
+  // NOTE: assert state lens of 5
+  for (const auto& res : casted_res) {
+    std::cout << res.first << "\n" << res.second << std::endl;
+  }
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/bark/world/tests/evaluation/capture_states_test.cc
+++ b/bark/world/tests/evaluation/capture_states_test.cc
@@ -19,7 +19,7 @@ using bark::commons::SetterParams;
 TEST(capture_test, base_functionality) {
   auto world = make_test_world(1, 5.0, 20.0, 0.0);
   // auto observed_worlds = world->Observe({1});
-  auto eval_capture_states = std::make_shared<EvaluatorCaptureStates>();
+  auto eval_capture_states = std::make_shared<EvaluatorCaptureAgentStates>();
   world->AddEvaluator("capture_states", eval_capture_states);
   auto eval_res = world->Evaluate();
 

--- a/bark/world/tests/evaluation/capture_states_test.cc
+++ b/bark/world/tests/evaluation/capture_states_test.cc
@@ -25,11 +25,11 @@ TEST(capture_test, base_functionality) {
 
   auto casted_res = boost::get<std::map<std::string, State>>(
     eval_res["capture_states"]);
-  // NOTE: assert size is 2
-  // NOTE: assert state_1 and state_2
-  // NOTE: assert state lens of 5
+  EXPECT_EQ(casted_res.size(), 2);
+  EXPECT_EQ(casted_res["state_1"], world->GetAgents()[1]->GetCurrentState());
+  EXPECT_EQ(casted_res["state_2"], world->GetAgents()[2]->GetCurrentState());
   for (const auto& res : casted_res) {
-    std::cout << res.first << "\n" << res.second << std::endl;
+    std::cout << res.first << ": \n" << res.second << std::endl;
   }
 }
 


### PR DESCRIPTION
Added an evaluator that captures all agent's states.

This enables to obtain all agents states by calling `world.Evaluate()` and allows, therefore, for state tracing.
