### PR TITLE
lat. filtering (FrontAgent) settable via parameter

### DIFF
--- a/bark/world/world.cpp
+++ b/bark/world/world.cpp
@@ -27,7 +27,10 @@ World::World(const commons::ParamsPtr& params)
       remove_agents_(params->GetBool(
           "World::remove_agents_out_of_map",
           "Whether agents should be removed outside the bounding box.",
-          false)) {
+          false)),
+      frac_lateral_offset_(params->GetReal("World::FracLateralOffset",
+          "Fraction of lateral offset for FrontRearAgent Calculation, should be larger than 0.",
+          0.5)) {
   //! segfault handler
   std::signal(SIGSEGV, bark::commons::SegfaultHandler);
 }
@@ -40,6 +43,7 @@ World::World(const std::shared_ptr<World>& world)
       evaluators_(world->GetEvaluators()),
       world_time_(world->GetWorldTime()),
       remove_agents_(world->GetRemoveAgents()),
+      frac_lateral_offset_(world->GetFracLateralOffset()),
       rtree_agents_(world->rtree_agents_) {
   //! segfault handler
   std::signal(SIGSEGV, bark::commons::SegfaultHandler);
@@ -245,7 +249,7 @@ FrontRearAgents World::GetAgentFrontRearForId(
 
     FrenetPosition frenet_other(it->second->GetCurrentPosition(), center_line);
     float width = lane_corridor->GetLaneWidth(it->second->GetCurrentPosition());
-    if (std::abs(frenet_other.lat) > width / 2) {
+    if (std::abs(frenet_other.lat) > frac_lateral_offset_ * width) {
       // agent seems to be not really in same lane
       continue;
     }

--- a/bark/world/world.hpp
+++ b/bark/world/world.hpp
@@ -128,6 +128,8 @@ class World : public commons::BaseType {
 
   bool GetRemoveAgents() { return remove_agents_; }
 
+  float GetFracLateralOffset() const { return frac_lateral_offset_; }
+
   void SetRemoveAgents(const bool& remove_agents) {
     remove_agents_ = remove_agents;
   }
@@ -177,6 +179,7 @@ class World : public commons::BaseType {
   double world_time_;
   AgentRTree rtree_agents_;
   bool remove_agents_;
+  float frac_lateral_offset_;
 };
 
 typedef std::shared_ptr<world::World> WorldPtr;

--- a/bark/world/world.hpp
+++ b/bark/world/world.hpp
@@ -128,7 +128,7 @@ class World : public commons::BaseType {
 
   bool GetRemoveAgents() { return remove_agents_; }
 
-  float GetFracLateralOffset() const { return frac_lateral_offset_; }
+  double GetFracLateralOffset() const { return frac_lateral_offset_; }
 
   void SetRemoveAgents(const bool& remove_agents) {
     remove_agents_ = remove_agents;
@@ -179,7 +179,7 @@ class World : public commons::BaseType {
   double world_time_;
   AgentRTree rtree_agents_;
   bool remove_agents_;
-  float frac_lateral_offset_;
+  double frac_lateral_offset_;
 };
 
 typedef std::shared_ptr<world::World> WorldPtr;

--- a/examples/merging.py
+++ b/examples/merging.py
@@ -42,11 +42,12 @@ param_server["BehaviorIDMClassic"]["BrakeForLaneEnd"] = True
 param_server["BehaviorIDMClassic"]["BrakeForLaneEndEnabledDistance"] = 60.0
 param_server["BehaviorIDMClassic"]["BrakeForLaneEndDistanceOffset"] = 30.0
 param_server["BehaviorLaneChangeRuleBased"]["MinRemainingLaneCorridorDistance"] = 80.
-param_server["BehaviorLaneChangeRuleBased"]["MinVehicleRearDistance"] = 1.
-param_server["BehaviorLaneChangeRuleBased"]["MinVehicleFrontDistance"] = 1.
+param_server["BehaviorLaneChangeRuleBased"]["MinVehicleRearDistance"] = 0.
+param_server["BehaviorLaneChangeRuleBased"]["MinVehicleFrontDistance"] = 0.
 param_server["BehaviorLaneChangeRuleBased"]["TimeKeepingGap"] = 0.
-param_server["BehaviorMobilRuleBased"]["Politeness"] = 0.1
+param_server["BehaviorMobilRuleBased"]["Politeness"] = 0.0
 param_server["BehaviorIDMClassic"]["DesiredVelocity"] = 10.
+param_server["World"]["FracLateralOffset"] = 0.8
 
 SetVerboseLevel(0)
 
@@ -103,7 +104,7 @@ env = Runtime(step_time=0.2,
               render=True)
 
 # run 3 scenarios
-for _ in range(0, 1):
+for _ in range(0, 3):
   env.reset()
   # step each scenario 20 times
   for step in range(0, 20):


### PR DESCRIPTION
As suggested by @juloberno  lateral filtering for GetFrontAndRearAgent based on lateral offset to center line can now be set via the parameter server. 
For frac_lateral_offset_ >= 1, it should work as before.