### PR TITLE
Update road_corridor_test.xodr to have left lane

### DIFF
--- a/bark/runtime/tests/data/road_corridor_test.xodr
+++ b/bark/runtime/tests/data/road_corridor_test.xodr
@@ -59,6 +59,19 @@
         </planView>
         <lanes>
             <laneSection s="0.0000000000000000e+00">
+                <left>
+                    <lane id="1" type="driving" level="0">
+                        <link>
+                            <predecessor id="1"/>
+                            <successor id="1"/>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="3.6000000000000001e+00" b="0.0000000000000000e+00"
+                               c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard"
+                                  width="1.4999999999999999e-01" laneChange="none" height="1.9999999552965164e-02">
+                        </roadMark>
+                    </lane>
+                </left>
                 <center>
                     <lane id="0" type="driving" level= "0">
                         <link>


### PR DESCRIPTION
My colleague found out that file `road_corridor_test.xodr` is missing left lane linkage from road:0 lane:1 to road:1 lane:1. When using it with carla it causes a segfault.

This PR is adding missing linkage info.