### PR TITLE
modify runtime.step function to allow for correct plotting

### DIFF
--- a/bark/runtime/runtime.py
+++ b/bark/runtime/runtime.py
@@ -37,10 +37,16 @@ class Runtime(PyRuntime):
     self._viewer.Reset()
 
   def step(self):
-    assert(self._reset_has_been_called==True)
-    self._world.Step(self._step_time)
+    assert(self._reset_has_been_called == True)
+    # instead of calling world.step() seperately, we call PlanAgents() and Execute() seperately
+    self._world.PlanAgents(self._step_time)
+
     if self._render:
-      self.render()
+        self.render()
+
+    inc_world_time = self._world.time + self._step_time
+    self._world.Execute(inc_world_time)
+    self._world.time = inc_world_time
 
   def render(self):
     # self._viewer.clear()


### PR DESCRIPTION
To allow for a correct plotting of planning information, I suggest to split the world.step() function within runtime.step().
This way, we generate the plans (via PlanAgents()) and can then plot it within the viewer.world() function. 
Only then, all agents shall move (via Execute). Otherwise, we are always plotting a planning result that does not match the world figure.