### PR TITLE
Fix RSS evaluator if agent is alone in scene

### DIFF
--- a/bark/world/evaluation/rss/evaluator_rss.hpp
+++ b/bark/world/evaluation/rss/evaluator_rss.hpp
@@ -75,8 +75,11 @@ class EvaluatorRSS : public BaseEvaluator {
   // lateral one is unsafety.
   virtual EvaluationReturn Evaluate(const World& world) {
     WorldPtr cloned_world = world.Clone();
-    ObservedWorld observed_world = cloned_world->Observe({agent_id_})[0];
-    return rss_.GetSafetyReponse(observed_world);
+    std::vector<ObservedWorld> observed_worlds = cloned_world->Observe({agent_id_});
+    if (observed_worlds.size() > 0) {
+      return rss_.GetSafetyReponse(observed_worlds[0]);
+    }
+    return false;
   };
 
   virtual EvaluationReturn Evaluate(const ObservedWorld& observed_world) {


### PR DESCRIPTION
The original PR has been closed, because the target branch was merged.

This occurs with the interaction dataset sometimes.

Refer to this comment to why I think this is expected behaviour and should not have a warning: https://github.com/bark-simulator/bark/pull/454#discussion_r525100246