### PR TITLE
Change RSS violation boolean - no evaluation

### DIFF
--- a/bark/world/evaluation/rss/evaluator_rss.hpp
+++ b/bark/world/evaluation/rss/evaluator_rss.hpp
@@ -55,11 +55,11 @@ class EvaluatorRSS : public BaseEvaluator {
         return rss_.GetSafetyReponse(observed_worlds[0]);
       } else {
         LOG(INFO) << "EvaluatorRSS not possible for agent " << agent_id_;
-        return false;
+        return true;
       }
     } else {
       LOG(INFO) << "EvaluatorRSS not possible for agent " << agent_id_;
-      return false;
+      return true;
     }
   }
 


### PR DESCRIPTION
Returning `true` from this method means, there was no violation. If there is nothing to evaluate then there cannot be an RSS violation. This means we should return `true` in those cases, not `false`.