### PR TITLE
SafetyPolygon for the RSS visualization and ScenarioDumper extension

### DIFF
--- a/bark/examples/highway_rss.py
+++ b/bark/examples/highway_rss.py
@@ -32,8 +32,10 @@ param_server["BehaviorLaneChangeRuleBased"]["MinVehicleFrontDistance"] = 2.
 param_server["BehaviorLaneChangeRuleBased"]["TimeKeepingGap"] = 0.
 param_server["World"]["FracLateralOffset"] = 2.0
 
-param_server["Visualization"]["Evaluation"]["DrawRssDebugInfo"] = True
-param_server["Visualization"]["Evaluation"]["DrawRssSafetyResponses"] = True
+# param_server["Visualization"]["Evaluation"]["DrawRssDebugInfo"] = True
+# param_server["Visualization"]["Evaluation"]["DrawRssSafetyResponses"] = True
+param_server["Visualization"]["Evaluation"]["DrawEgoRSSSafetyResponses"] = True
+
 
 # custom lane configuration that sets a different behavior model
 # and sets the desired speed for the behavior
@@ -128,7 +130,8 @@ for episode in range(0, 3):
     env.reset()
     current_world = env._world
     eval_agent_id = env._scenario._eval_agent_ids[0]
-
+    current_world.agents[eval_agent_id].behavior_model = \
+      BehaviorRSSConformant(param_server)
     evaluator_rss = EvaluatorRSS(eval_agent_id, param_server)
 
     current_world.AddEvaluator("rss", evaluator_rss)

--- a/bark/examples/merging_rss.py
+++ b/bark/examples/merging_rss.py
@@ -105,7 +105,7 @@ viewer = MPViewer(params=param_server,
 
 sim_step_time = param_server["simulation"]["step_time",
                                            "Step-time used in simulation",
-                                           0.2]
+                                           0.05]
 sim_real_time_factor = param_server["simulation"]["real_time_factor",
                                                   "execution in real-time or faster",
                                                   1.]

--- a/bark/examples/merging_rss.py
+++ b/bark/examples/merging_rss.py
@@ -58,6 +58,7 @@ param_server["BehaviorLaneChangeRuleBased"]["TimeKeepingGap"] = 0.
 param_server["BehaviorMobilRuleBased"]["Politeness"] = 0.0
 param_server["BehaviorIDMClassic"]["DesiredVelocity"] = 10.
 param_server["World"]["FracLateralOffset"] = 2.0
+param_server["Visualization"]["Agents"]["DrawAgentId"] =  True
 
 # param_server["Visualization"]["Evaluation"]["DrawRssDebugInfo"] = True
 # param_server["Visualization"]["Evaluation"]["DrawRssSafetyResponses"] = True

--- a/bark/examples/merging_rss.py
+++ b/bark/examples/merging_rss.py
@@ -49,9 +49,9 @@ class CustomLaneCorridorConfig(LaneCorridorConfig):
 
 
 param_server["BehaviorIDMClassic"]["BrakeForLaneEnd"] = True
-param_server["BehaviorIDMClassic"]["BrakeForLaneEndEnabledDistance"] = 60.0
-param_server["BehaviorIDMClassic"]["BrakeForLaneEndDistanceOffset"] = 30.0
-param_server["BehaviorLaneChangeRuleBased"]["MinRemainingLaneCorridorDistance"] = 80.
+param_server["BehaviorIDMClassic"]["BrakeForLaneEndEnabledDistance"] = 25.0
+param_server["BehaviorIDMClassic"]["BrakeForLaneEndDistanceOffset"] = 25.0
+param_server["BehaviorLaneChangeRuleBased"]["MinRemainingLaneCorridorDistance"] = 20.
 param_server["BehaviorLaneChangeRuleBased"]["MinVehicleRearDistance"] = 0.
 param_server["BehaviorLaneChangeRuleBased"]["MinVehicleFrontDistance"] = 0.
 param_server["BehaviorLaneChangeRuleBased"]["TimeKeepingGap"] = 0.

--- a/bark/models/behavior/behavior_rss/BUILD
+++ b/bark/models/behavior/behavior_rss/BUILD
@@ -15,7 +15,8 @@ cc_library(
         "//bark/world:world",
         "//bark/models/behavior/behavior_safety:behavior_safety",
         "//bark/models/dynamic:dynamic",
-        "//bark/world/evaluation:evaluation"
+        "//bark/world/evaluation:evaluation",
+        "//bark/world/evaluation/rss:safety_polygon"
     ] +  select({
         "//bark/world/evaluation/rss:_rss": ["//bark/world/evaluation/rss:evaluator_rss"],
         "//conditions:default": [],

--- a/bark/models/behavior/behavior_rss/behavior_rss.cpp
+++ b/bark/models/behavior/behavior_rss/behavior_rss.cpp
@@ -70,6 +70,7 @@ Trajectory BehaviorRSSConformant::Plan(
     lat_left_response_ = rss_response.lateralResponseLeft;
     lat_right_response_ = rss_response.lateralResponseRight;
     acc_restrictions_ = rss_response.accelerationRestrictions;
+    safety_polygons_ = rss_evaluator->GetSafetyPolygons();
   }
 #endif
 

--- a/bark/models/behavior/behavior_rss/behavior_rss.hpp
+++ b/bark/models/behavior/behavior_rss/behavior_rss.hpp
@@ -34,6 +34,7 @@ using world::ObservedWorld;
 using world::evaluation::BaseEvaluator;
 using world::objects::AgentId;
 using world::evaluation::SafetyPolygon;
+using world::evaluation::ComputeSafetyPolygon;
 #ifdef RSS
 using bark::world::evaluation::EvaluatorRSS;
 #endif
@@ -121,6 +122,11 @@ class BehaviorRSSConformant : public BehaviorModel {
     lat_right_response_ =
         static_cast<::ad::rss::state::LateralResponse>(lat_right);
   }
+  void ComputeSafetyPolygons(const ObservedWorld& observed_world) {
+    for (auto& sp : safety_polygons_)
+      ComputeSafetyPolygon(sp, observed_world);
+  }
+
 #endif
   std::vector<SafetyPolygon> GetSafetyPolygons() const {
     return safety_polygons_;

--- a/bark/models/behavior/behavior_rss/behavior_rss.hpp
+++ b/bark/models/behavior/behavior_rss/behavior_rss.hpp
@@ -18,6 +18,7 @@
 #ifdef RSS
 #include "bark/world/evaluation/rss/evaluator_rss.hpp"
 #endif
+#include "bark/world/evaluation/rss/safety_polygon.hpp"
 #include "bark/world/world.hpp"
 
 namespace bark {
@@ -32,6 +33,7 @@ using dynamic::Trajectory;
 using world::ObservedWorld;
 using world::evaluation::BaseEvaluator;
 using world::objects::AgentId;
+using world::evaluation::SafetyPolygon;
 #ifdef RSS
 using bark::world::evaluation::EvaluatorRSS;
 #endif
@@ -120,7 +122,12 @@ class BehaviorRSSConformant : public BehaviorModel {
         static_cast<::ad::rss::state::LateralResponse>(lat_right);
   }
 #endif
-
+  std::vector<SafetyPolygon> GetSafetyPolygons() const {
+    return safety_polygons_;
+  }
+  void SetSafetyPolygons(const std::vector<SafetyPolygon>& sp) {
+    safety_polygons_ = sp;
+  }
  private:
   std::shared_ptr<BehaviorModel> nominal_behavior_model_;
   std::shared_ptr<BehaviorSafety> behavior_safety_model_;
@@ -134,6 +141,7 @@ class BehaviorRSSConformant : public BehaviorModel {
   ::ad::rss::state::LateralResponse lat_left_response_;
   ::ad::rss::state::LateralResponse lat_right_response_;
   ::ad::rss::state::AccelerationRestriction acc_restrictions_;
+  std::vector<SafetyPolygon> safety_polygons_;
   #endif
 };
 

--- a/bark/python_wrapper/BUILD
+++ b/bark/python_wrapper/BUILD
@@ -45,7 +45,8 @@ cc_binary(
     "//bark/world:world",
     "//bark/runtime:cc_runtime",
     "//bark/python_wrapper/models/plan:planners",
-    "//bark/python_wrapper/tests:logging_tests"
+    "//bark/python_wrapper/tests:logging_tests",
+    "//bark/world/evaluation/rss:safety_polygon"
   ] + select({"//bark/models/behavior/plan:_planner_uct" : ["@planner_uct//bark_mcts/python_wrapper:planner_uct"], "//conditions:default": []})
   + select({"//bark/models/behavior/plan:_planner_rules_mcts" : ["@planner_rules_mcts//python:planner_rules_mcts"], "//conditions:default": []})
   + select({"//bark/models/behavior/plan:_planner_miqp" : ["@planner_miqp//python/bindings:planner_miqp"], "//conditions:default": []})

--- a/bark/python_wrapper/models/behavior.cpp
+++ b/bark/python_wrapper/models/behavior.cpp
@@ -443,7 +443,8 @@ void python_behavior(py::module m) {
           ParamsToPython(b.GetBehaviorSafetyModel()->GetParams()),
           b.GetLongitudinalResponse(),
           b.GetLateralLeftResponse(),
-          b.GetLateralRightResponse());
+          b.GetLateralRightResponse(),
+          b.GetSafetyPolygons());
         #endif
         return py::make_tuple(
           ParamsToPython(b.GetParams()), 
@@ -453,7 +454,7 @@ void python_behavior(py::module m) {
       [](py::tuple t) {
         int num_params = 3;
         #ifdef RSS
-        num_params = 6;
+        num_params = 7;
         #endif
         if (t.size() != num_params)
           throw std::runtime_error("Invalid behavior model state!");
@@ -471,6 +472,7 @@ void python_behavior(py::module m) {
         bm->SetLongitudinalResponse(t[3].cast<bool>());
         bm->SetLateralLeftResponse(t[4].cast<bool>());
         bm->SetLateralRightResponse(t[5].cast<bool>());
+        bm->SetSafetyPolygons(t[6].cast<std::vector<SafetyPolygon>>());
         // TODO: load safety polygons
         #endif
         return bm;

--- a/bark/python_wrapper/models/behavior.cpp
+++ b/bark/python_wrapper/models/behavior.cpp
@@ -429,6 +429,7 @@ void python_behavior(py::module m) {
     .def("SetLateralLeftResponse", &BehaviorRSSConformant::SetLateralLeftResponse)
     .def("SetLateralRightResponse", &BehaviorRSSConformant::SetLateralRightResponse)
     .def("GetSafetyPolygons", &BehaviorRSSConformant::GetSafetyPolygons)
+    .def("ComputeSafetyPolygons", &BehaviorRSSConformant::ComputeSafetyPolygons)
     #endif
     .def("__repr__",
       [](const BehaviorRSSConformant& b) {

--- a/bark/python_wrapper/models/behavior.cpp
+++ b/bark/python_wrapper/models/behavior.cpp
@@ -435,6 +435,7 @@ void python_behavior(py::module m) {
       })
     .def(py::pickle(
       [](const BehaviorRSSConformant& b) {
+        // TODO: store safety polygons
         #ifdef RSS
         return py::make_tuple(
           ParamsToPython(b.GetParams()), 
@@ -470,6 +471,7 @@ void python_behavior(py::module m) {
         bm->SetLongitudinalResponse(t[3].cast<bool>());
         bm->SetLateralLeftResponse(t[4].cast<bool>());
         bm->SetLateralRightResponse(t[5].cast<bool>());
+        // TODO: load safety polygons
         #endif
         return bm;
       }));

--- a/bark/python_wrapper/models/behavior.cpp
+++ b/bark/python_wrapper/models/behavior.cpp
@@ -428,6 +428,7 @@ void python_behavior(py::module m) {
     .def("SetLongitudinalResponse", &BehaviorRSSConformant::SetLongitudinalResponse)
     .def("SetLateralLeftResponse", &BehaviorRSSConformant::SetLateralLeftResponse)
     .def("SetLateralRightResponse", &BehaviorRSSConformant::SetLateralRightResponse)
+    .def("GetSafetyPolygons", &BehaviorRSSConformant::GetSafetyPolygons)
     #endif
     .def("__repr__",
       [](const BehaviorRSSConformant& b) {

--- a/bark/python_wrapper/world/evaluation.cpp
+++ b/bark/python_wrapper/world/evaluation.cpp
@@ -87,6 +87,7 @@ void python_evaluation(py::module m) {
   py::class_<SafetyPolygon,
              std::shared_ptr<SafetyPolygon>>(m, "SafetyPolygon")
     .def(py::init<>())
+    .def("GetPolygon", &SafetyPolygon::GetPolygon)
     .def("__repr__", [](const SafetyPolygon& g) {
       return "bark.core.world.evaluation.SafetyPolygon";
   })

--- a/bark/python_wrapper/world/evaluation.cpp
+++ b/bark/python_wrapper/world/evaluation.cpp
@@ -88,23 +88,27 @@ void python_evaluation(py::module m) {
              std::shared_ptr<SafetyPolygon>>(m, "SafetyPolygon")
     .def(py::init<>())
     .def("GetPolygon", &SafetyPolygon::GetPolygon)
-    .def("__repr__", [](const SafetyPolygon& g) {
-      return "bark.core.world.evaluation.SafetyPolygon";
-  })
-  .def(py::pickle(
-    [](const SafetyPolygon& a) {
-      // make tuple here
-      return py::make_tuple(
-        a.lat_left_safety_distance, a.lat_right_safety_distance,
-        a.lon_safety_distance, a.polygon);
-    },
-    [](py::tuple t) {
-      if (t.size() != 4)
-        throw std::runtime_error("Invalid SafetyPolygon model state!");
-      return new SafetyPolygon{
-        t[0].cast<double>(), t[1].cast<double>(),
-        t[2].cast<double>(), t[3].cast<Polygon>()};
-  }));
+    .def("__repr__",
+      [](const SafetyPolygon& poly) {
+        std::stringstream ss;
+        ss << "<bark.SafetyPolygon>: ";
+        ss << poly;
+        return ss.str();
+      })
+    .def(py::pickle(
+      [](const SafetyPolygon& a) {
+        // make tuple here
+        return py::make_tuple(
+          a.lat_left_safety_distance, a.lat_right_safety_distance,
+          a.lon_safety_distance, a.polygon);
+      },
+      [](py::tuple t) {
+        if (t.size() != 4)
+          throw std::runtime_error("Invalid SafetyPolygon model state!");
+        return new SafetyPolygon{
+          t[0].cast<double>(), t[1].cast<double>(),
+          t[2].cast<double>(), t[3].cast<Polygon>()};
+    }));
 
 
 #ifdef RSS

--- a/bark/python_wrapper/world/evaluation.cpp
+++ b/bark/python_wrapper/world/evaluation.cpp
@@ -101,14 +101,14 @@ void python_evaluation(py::module m) {
         // make tuple here
         return py::make_tuple(
           a.lat_left_safety_distance, a.lat_right_safety_distance,
-          a.lon_safety_distance, a.polygon, a.agent_id);
+          a.lon_safety_distance, a.polygon, a.agent_id, a.curr_distance);
       },
       [](py::tuple t) {
-        if (t.size() != 5)
+        if (t.size() != 6)
           throw std::runtime_error("Invalid SafetyPolygon model state!");
         return new SafetyPolygon{
           t[0].cast<double>(), t[1].cast<double>(), t[2].cast<double>(),
-          t[3].cast<Polygon>(), t[4].cast<AgentId>()};
+          t[3].cast<Polygon>(), t[4].cast<AgentId>(), t[5].cast<double>()};
     }));
 
 

--- a/bark/python_wrapper/world/evaluation.cpp
+++ b/bark/python_wrapper/world/evaluation.cpp
@@ -26,7 +26,7 @@ namespace py = pybind11;
 
 void python_evaluation(py::module m) {
   using namespace bark::world::evaluation;
-  using geometry::Polygon;
+  using bark::geometry::Polygon;
 
   py::class_<BaseEvaluator, PyBaseEvaluator, EvaluatorPtr>(m, "BaseEvaluator")
       .def(py::init<>())

--- a/bark/python_wrapper/world/evaluation.cpp
+++ b/bark/python_wrapper/world/evaluation.cpp
@@ -88,6 +88,7 @@ void python_evaluation(py::module m) {
              std::shared_ptr<SafetyPolygon>>(m, "SafetyPolygon")
     .def(py::init<>())
     .def("GetPolygon", &SafetyPolygon::GetPolygon)
+    .def("GetAgentId", &SafetyPolygon::GetAgentId)
     .def("__repr__",
       [](const SafetyPolygon& poly) {
         std::stringstream ss;
@@ -100,14 +101,14 @@ void python_evaluation(py::module m) {
         // make tuple here
         return py::make_tuple(
           a.lat_left_safety_distance, a.lat_right_safety_distance,
-          a.lon_safety_distance, a.polygon);
+          a.lon_safety_distance, a.polygon, a.agent_id);
       },
       [](py::tuple t) {
-        if (t.size() != 4)
+        if (t.size() != 5)
           throw std::runtime_error("Invalid SafetyPolygon model state!");
         return new SafetyPolygon{
-          t[0].cast<double>(), t[1].cast<double>(),
-          t[2].cast<double>(), t[3].cast<Polygon>()};
+          t[0].cast<double>(), t[1].cast<double>(), t[2].cast<double>(),
+          t[3].cast<Polygon>(), t[4].cast<AgentId>()};
     }));
 
 

--- a/bark/runtime/viewer/viewer.py
+++ b/bark/runtime/viewer/viewer.py
@@ -491,6 +491,7 @@ class BaseViewer(Viewer):
         
         safety_polygons = behavior.GetSafetyPolygons()
         for poly in safety_polygons:
+          print(poly)
           self.drawPolygon2d(poly.GetPolygon(), "Blue", 0.6, "Blue", zorder=9)
           
         # draw labels

--- a/bark/runtime/viewer/viewer.py
+++ b/bark/runtime/viewer/viewer.py
@@ -496,7 +496,8 @@ class BaseViewer(Viewer):
         
         for poly in safety_polygons:
           print(poly)
-          self.drawPolygon2d(poly.GetPolygon(), "Blue", 0.6, "Blue", zorder=9)
+          color_face = self.agent_color_map[poly.GetAgentId()]
+          self.drawPolygon2d(poly.GetPolygon(), color_face, 0.3, color_face, zorder=9)
           
         # draw labels
         ego_agent = world.agents[agent_id]

--- a/bark/runtime/viewer/viewer.py
+++ b/bark/runtime/viewer/viewer.py
@@ -488,6 +488,10 @@ class BaseViewer(Viewer):
         if lateral_left_response != 0 or lateral_right_response != 0:
           print("Lateral violation")
           violations.append({"label": "LAT", "color": "red"})
+        
+        safety_polygons = behavior.GetSafetyPolygons()
+        for poly in safety_polygons:
+          self.drawPolygon2d(poly.GetPolygon(), "Blue", 0.6, "Blue", zorder=9)
           
         # draw labels
         ego_agent = world.agents[agent_id]

--- a/bark/runtime/viewer/viewer.py
+++ b/bark/runtime/viewer/viewer.py
@@ -489,7 +489,11 @@ class BaseViewer(Viewer):
           print("Lateral violation")
           violations.append({"label": "LAT", "color": "red"})
         
+        # have to compute shape here
+        observed_world = world.Observe([agent_id])[0]
+        behavior.ComputeSafetyPolygons(observed_world)
         safety_polygons = behavior.GetSafetyPolygons()
+        
         for poly in safety_polygons:
           print(poly)
           self.drawPolygon2d(poly.GetPolygon(), "Blue", 0.6, "Blue", zorder=9)

--- a/bark/world/evaluation/rss/BUILD
+++ b/bark/world/evaluation/rss/BUILD
@@ -24,6 +24,15 @@ cc_library(
 )
 
 cc_library(
+    name = "safety_polygon",
+    hdrs = ["safety_polygon.hpp"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//bark/world:world",
+    ]
+)
+
+cc_library(
     name = "evaluator_rss",
     hdrs = ["evaluator_rss.hpp"],
     visibility = ["//visibility:public"],
@@ -31,6 +40,7 @@ cc_library(
         "//bark/world:world",
         "//bark/world/evaluation:base_evaluator",
         ":_rss_interface",
+        ":safety_polygon"
     ]
 )
 

--- a/bark/world/evaluation/rss/evaluator_rss.hpp
+++ b/bark/world/evaluation/rss/evaluator_rss.hpp
@@ -69,12 +69,16 @@ class EvaluatorRSS : public BaseEvaluator {
     }
   }
 
-  double GetSafeDistance(const ::ad::rss::state::LongitudinalRssState& rss_state) {
+  // double GetSafeDistance(const ::ad::rss::state::LongitudinalRssState& rss_state) {
+
+  template<typename T>
+  double GetSafeDistance(const T& rss_state) {
     return rss_state.rssStateInformation.safeDistance;
   }
 
-  double GetSafeDistance(const ::ad::rss::state::LateralRssState& rss_state) {
-    return rss_state.rssStateInformation.safeDistance;
+  template<typename T>
+  double GetCurrentDistance(const T& rss_state) {
+    return rss_state.rssStateInformation.currentDistance;
   }
 
   void GenerateSafetyPolygons(const ObservedWorld& observed_world) {
@@ -85,6 +89,7 @@ class EvaluatorRSS : public BaseEvaluator {
       safe_poly.lat_left_safety_distance = GetSafeDistance(rss_state.lateralStateLeft);
       safe_poly.lat_right_safety_distance = GetSafeDistance(rss_state.lateralStateRight);
       safe_poly.agent_id = rss_state.objectId;
+      safe_poly.curr_distance = GetCurrentDistance(rss_state.longitudinalState);
       safety_polygons_.push_back(safe_poly);
     }
   }

--- a/bark/world/evaluation/rss/evaluator_rss.hpp
+++ b/bark/world/evaluation/rss/evaluator_rss.hpp
@@ -84,6 +84,7 @@ class EvaluatorRSS : public BaseEvaluator {
       safe_poly.lon_safety_distance = GetSafeDistance(rss_state.longitudinalState);
       safe_poly.lat_left_safety_distance = GetSafeDistance(rss_state.lateralStateLeft);
       safe_poly.lat_right_safety_distance = GetSafeDistance(rss_state.lateralStateRight);
+      safe_poly.agent_id = rss_state.objectId;
       safety_polygons_.push_back(safe_poly);
     }
   }

--- a/bark/world/evaluation/rss/evaluator_rss.hpp
+++ b/bark/world/evaluation/rss/evaluator_rss.hpp
@@ -86,7 +86,6 @@ class EvaluatorRSS : public BaseEvaluator {
   void GenerateSafetyPolygons(const ObservedWorld& observed_world) {
     safety_polygons_.clear();
     for (auto& rss_state : rss_state_snapshot_.individualResponses) {
-      // from agent_id, to_agent_id
       SafetyPolygon safe_poly;
       safe_poly.lon_safety_distance = GetSafeDistance(rss_state.longitudinalState);
       safe_poly.lat_left_safety_distance = GetSafeDistance(rss_state.lateralStateLeft);
@@ -149,6 +148,10 @@ class EvaluatorRSS : public BaseEvaluator {
     return rss_proper_response_;
   }
 
+  std::vector<SafetyPolygon> GetSafetyPolygons() const {
+    return safety_polygons_;
+  }
+  
   virtual ~EvaluatorRSS() {}
 
  private:

--- a/bark/world/evaluation/rss/evaluator_rss.hpp
+++ b/bark/world/evaluation/rss/evaluator_rss.hpp
@@ -77,46 +77,6 @@ class EvaluatorRSS : public BaseEvaluator {
     return rss_state.rssStateInformation.safeDistance;
   }
 
-  void ComputeSafetyPolygon(
-    SafetyPolygon& safe_poly, const ObservedWorld& observed_world) {
-    // 1. copy shape and inser into safe_poly
-    auto ego_agent = observed_world.GetEgoAgent();
-    auto ego_pose = ego_agent->GetCurrentPosition();
-    auto ego_state = ego_agent->GetCurrentState();
-    auto theta = ego_state(StateDefinition::THETA_POSITION);
-
-    // 2. transform
-    std::vector<Point2d> points = ego_agent->GetPolygonFromState(ego_state).obj_.outer();
-    for (auto pt : points) {
-      double pt_angle = atan2(
-        bg::get<1>(ego_pose) - bg::get<1>(pt),
-        bg::get<0>(ego_pose) - bg::get<0>(pt));
-      double signed_angle_diff_lat = SignedAngleDiff(theta, pt_angle);
-      double signed_angle_diff_lon = SignedAngleDiff(theta - 3.14/2., pt_angle);
-      double sgn_lat = signed_angle_diff_lat > 0 ? 1 : -1;
-      double sgn_lon = signed_angle_diff_lon > 0 ? 1 : -1;
-
-      // lateral safety distancesa
-      double lat_dist = 0;
-      lat_dist =  sgn_lat < 0 ? safe_poly.lat_left_safety_distance : safe_poly.lat_right_safety_distance;  // NOLINT
-      auto lat_proj_angle = sgn_lat < 0 ? theta - 3.14/2. : theta + 3.14/2.;
-      if (sgn_lat < 0) {
-        auto x_new = bg::get<0>(pt) + lat_dist*cos(lat_proj_angle);
-        auto y_new = bg::get<1>(pt) + lat_dist*sin(lat_proj_angle);
-        bg::set<0>(pt, x_new);
-        bg::set<1>(pt, y_new);
-      }
-
-      // longitudinal back and front safety distance
-      bg::set<0>(
-        pt, bg::get<0>(pt) + sgn_lon*safe_poly.lon_safety_distance*cos(theta));
-      bg::set<1>(
-        pt, bg::get<1>(pt) + sgn_lon*safe_poly.lon_safety_distance*sin(theta));
-      safe_poly.polygon.AddPoint(pt);
-    }
-
-  }
-
   void GenerateSafetyPolygons(const ObservedWorld& observed_world) {
     safety_polygons_.clear();
     for (auto& rss_state : rss_state_snapshot_.individualResponses) {
@@ -124,7 +84,6 @@ class EvaluatorRSS : public BaseEvaluator {
       safe_poly.lon_safety_distance = GetSafeDistance(rss_state.longitudinalState);
       safe_poly.lat_left_safety_distance = GetSafeDistance(rss_state.lateralStateLeft);
       safe_poly.lat_right_safety_distance = GetSafeDistance(rss_state.lateralStateRight);
-      ComputeSafetyPolygon(safe_poly, observed_world);
       safety_polygons_.push_back(safe_poly);
     }
   }

--- a/bark/world/evaluation/rss/evaluator_rss.hpp
+++ b/bark/world/evaluation/rss/evaluator_rss.hpp
@@ -86,34 +86,32 @@ class EvaluatorRSS : public BaseEvaluator {
     auto theta = ego_state(StateDefinition::THETA_POSITION);
 
     // 2. transform
-    // -> angle_diff_lat = SignedAngleDiff(theta, pt_angle) -> lat (+/-)
-    // x sign(angle_diff_lat)= lat_brake*sin(theta)
-    // y sign(angle_diff_lat)= lat_brake*cos(theta)
-    // -> angle_diff_lon = SignedAngleDiff(theta + pi/2, pt_angle) -> lon (+/-)
-    // x sign(angle_diff_lon)= lat_brake*cos(theta)
-    // y sign(angle_diff_lon)= lat_brake*sin(theta)
-    std::vector<Point2d> points = ego_agent->GetShape().obj_.outer();
+    std::vector<Point2d> points = ego_agent->GetPolygonFromState(ego_state).obj_.outer();
     for (auto pt : points) {
       double pt_angle = atan2(
-        bg::get<1>(pt) - bg::get<1>(ego_pose),
-        bg::get<0>(pt) - bg::get<0>(ego_pose));
+        bg::get<1>(ego_pose) - bg::get<1>(pt),
+        bg::get<0>(ego_pose) - bg::get<0>(pt));
       double signed_angle_diff_lat = SignedAngleDiff(theta, pt_angle);
-      double signed_angle_diff_lon = SignedAngleDiff(theta, pt_angle);
+      double signed_angle_diff_lon = SignedAngleDiff(theta - 3.14/2., pt_angle);
       double sgn_lat = signed_angle_diff_lat > 0 ? 1 : -1;
       double sgn_lon = signed_angle_diff_lon > 0 ? 1 : -1;
 
-      // lateral
+      // lateral safety distancesa
       double lat_dist = 0;
       lat_dist =  sgn_lat < 0 ? safe_poly.lat_left_safety_distance : safe_poly.lat_right_safety_distance;  // NOLINT
-      bg::set<0>(pt, bg::get<0>(pt) + sgn_lat*lat_dist*sin(theta));
-      bg::set<1>(pt, bg::get<1>(pt) + sgn_lat*lat_dist*cos(theta));
+      auto lat_proj_angle = sgn_lat < 0 ? theta - 3.14/2. : theta + 3.14/2.;
+      if (sgn_lat < 0) {
+        auto x_new = bg::get<0>(pt) + lat_dist*cos(lat_proj_angle);
+        auto y_new = bg::get<1>(pt) + lat_dist*sin(lat_proj_angle);
+        bg::set<0>(pt, x_new);
+        bg::set<1>(pt, y_new);
+      }
 
-      // longitudinal back and front
+      // longitudinal back and front safety distance
       bg::set<0>(
         pt, bg::get<0>(pt) + sgn_lon*safe_poly.lon_safety_distance*cos(theta));
       bg::set<1>(
         pt, bg::get<1>(pt) + sgn_lon*safe_poly.lon_safety_distance*sin(theta));
-
       safe_poly.polygon.AddPoint(pt);
     }
 

--- a/bark/world/evaluation/rss/evaluator_rss.hpp
+++ b/bark/world/evaluation/rss/evaluator_rss.hpp
@@ -75,11 +75,15 @@ class EvaluatorRSS : public BaseEvaluator {
     return rss_state.rssStateInformation.safeDistance;
   }
 
-  void ComputeSafetyPolygon(SafetyPolygon& safe_poly) {
+  void ComputeSafetyPolygon(
+    SafetyPolygon& safe_poly, const ObservedWorld& observed_world) {
     // TODO: generate and fill safety polygon here
+    // auto ego_agent = observed_world.Get
+    // 1. calculate bounding box
+    // 2. enlarge bounding box in longitudinal
   }
 
-  void GenerateSafetyPolygons() {
+  void GenerateSafetyPolygons(const ObservedWorld& observed_world) {
     safety_polygons_.clear();
     for (auto& rss_state : rss_state_snapshot_.individualResponses) {
       // from agent_id, to_agent_id
@@ -87,7 +91,8 @@ class EvaluatorRSS : public BaseEvaluator {
       safe_poly.lon_safety_distance = GetSafeDistance(rss_state.longitudinalState);
       safe_poly.lat_left_safety_distance = GetSafeDistance(rss_state.lateralStateLeft);
       safe_poly.lat_right_safety_distance = GetSafeDistance(rss_state.lateralStateRight);
-      ComputeSafetyPolygon(safe_poly);
+      ComputeSafetyPolygon(safe_poly, observed_world);
+      // std::cout << safe_poly << std::endl;
       safety_polygons_.push_back(safe_poly);
     }
   }
@@ -96,7 +101,7 @@ class EvaluatorRSS : public BaseEvaluator {
     auto result = rss_.GetSafetyReponse(observed_world);
     rss_proper_response_ = rss_.GetRSSResponse();
     rss_state_snapshot_ = rss_.GetRSSStateSnapshot();
-    GenerateSafetyPolygons();
+    GenerateSafetyPolygons(observed_world);
     return rss_.GetSafetyReponse(observed_world);
   };
 
@@ -148,10 +153,8 @@ class EvaluatorRSS : public BaseEvaluator {
 
  private:
   RssInterface rss_;
-  std::vector<uint64_t> dangerous_objects_{};
   ::ad::rss::state::ProperResponse rss_proper_response_;
   ::ad::rss::state::RssStateSnapshot rss_state_snapshot_;
-  // TODO: serialize this
   std::vector<SafetyPolygon> safety_polygons_;
 
 #endif

--- a/bark/world/evaluation/rss/rss_interface.cpp
+++ b/bark/world/evaluation/rss/rss_interface.cpp
@@ -352,17 +352,15 @@ bool RssInterface::RssCheck(
   // Describes the relative relation between two objects in possible
   // situations
   ::ad::rss::situation::SituationSnapshot situation_snapshot;
-
   // rss_state_snapshot: individual situation responses calculated from
   // SituationSnapshot
   bool result = rss_check.calculateProperResponse(
-      world_model, situation_snapshot, rss_state_snapshot,
+      world_model, situation_snapshot, rss_state_snapshot_,
       rss_proper_response_);
 
   if (!result) {
     LOG(ERROR) << "Failed to perform RSS check" << std::endl;
   }
-
   return result;
 }
 

--- a/bark/world/evaluation/rss/rss_interface.hpp
+++ b/bark/world/evaluation/rss/rss_interface.hpp
@@ -225,7 +225,11 @@ class RssInterface {
   ::ad::rss::state::ProperResponse GetRSSResponse() const {
     return rss_proper_response_;
   }
-  
+
+  ::ad::rss::state::RssStateSnapshot GetRSSStateSnapshot() const {
+    return rss_state_snapshot_;
+  }
+
  private:
   // For a detailed explanation of parameters, please see:
   // https://intel.github.io/ad-rss-lib/ad_rss/Appendix-ParameterDiscussion/#parameter-discussion
@@ -241,6 +245,7 @@ class RssInterface {
   // Contains longitudinal and lateral response of the ego object, a list of
   // id of the dangerous objects
   ::ad::rss::state::ProperResponse rss_proper_response_;
+  ::ad::rss::state::RssStateSnapshot rss_state_snapshot_;
 };
 
 }  // namespace evaluation

--- a/bark/world/evaluation/rss/safety_polygon.hpp
+++ b/bark/world/evaluation/rss/safety_polygon.hpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 fortiss GmbH
+//
+// Authors: Julian Bernhard, Klemens Esterle, Patrick Hart and
+// Tobias Kessler
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#ifndef BARK_WORLD_EVALUATION_SAFETY_POLYGON_HPP_
+#define BARK_WORLD_EVALUATION_SAFETY_POLYGON_HPP_
+
+#include <limits>
+#include <memory>
+#include <string>
+
+#include "bark/geometry/polygon.hpp"
+#include "bark/world/world.hpp"
+
+
+namespace bark {
+namespace world {
+namespace evaluation {
+
+using geometry::Polygon;
+using bark::world::AgentId;
+
+// TODO: make serializable
+struct SafetyPolygon {
+  double lat_left_safety_distance;
+  double lat_right_safety_distance;
+  double lon_safety_distance;
+  Polygon polygon;
+  AgentId from_id, to_id;
+};
+
+typedef std::shared_ptr<SafetyPolygon> SafetyPolygonPtr;
+
+}  // namespace evaluation
+}  // namespace world
+}  // namespace bark
+
+#endif  // BARK_WORLD_EVALUATION_SAFETY_POLYGON_HPP_

--- a/bark/world/evaluation/rss/safety_polygon.hpp
+++ b/bark/world/evaluation/rss/safety_polygon.hpp
@@ -62,15 +62,15 @@ inline void ComputeSafetyPolygon(
       bg::get<1>(ego_pose) - bg::get<1>(pt),
       bg::get<0>(ego_pose) - bg::get<0>(pt));
     double signed_angle_diff_lat = SignedAngleDiff(theta, pt_angle);
-    double signed_angle_diff_lon = SignedAngleDiff(theta - 3.14/2., pt_angle);
+    double signed_angle_diff_lon = SignedAngleDiff(theta - M_PI_2, pt_angle);
     double sgn_lat = signed_angle_diff_lat > 0 ? 1 : -1;
     double sgn_lon = signed_angle_diff_lon > 0 ? 1 : -1;
 
     // lateral safety distances
     double lat_dist = 0;
     lat_dist =  sgn_lat < 0 ? safe_poly.lat_left_safety_distance : safe_poly.lat_right_safety_distance;  // NOLINT
-    auto lat_proj_angle = sgn_lat > 0 ? theta - 3.14/2. : theta + 3.14/2.;
-    if (sgn_lat < 0) {
+    auto lat_proj_angle = sgn_lat < 0 ? theta - M_PI_2 : theta + M_PI_2;
+    if (lat_dist < 10000) {
       auto x_new = bg::get<0>(pt) + lat_dist*cos(lat_proj_angle);
       auto y_new = bg::get<1>(pt) + lat_dist*sin(lat_proj_angle);
       bg::set<0>(pt, x_new);
@@ -83,12 +83,13 @@ inline void ComputeSafetyPolygon(
     double relative_angle = atan2(
       bg::get<1>(ego_pose) - bg::get<1>(other_pose),
       bg::get<0>(ego_pose) - bg::get<0>(other_pose));
-    double diff_angle = SignedAngleDiff(theta - 3.14/2., relative_angle);
+    double diff_angle = SignedAngleDiff(theta - M_PI_2, relative_angle);
     double sgn_lon_in_front = diff_angle > 0 ? 1 : -1;
 
     // if the signs are different we do not want to modify the original
     // point of the polygon
-    if (sgn_lon_in_front*sgn_lon < 0.)
+    if (sgn_lon_in_front*sgn_lon < 0. ||
+        safe_poly.lon_safety_distance > 10000.)
       sgn_lon = 0.;
 
     // longitudinal back and front safety distance

--- a/bark/world/evaluation/rss/safety_polygon.hpp
+++ b/bark/world/evaluation/rss/safety_polygon.hpp
@@ -26,9 +26,9 @@ using bark::world::AgentId;
 
 // TODO: make serializable
 struct SafetyPolygon {
-  double lat_left_safety_distance;
-  double lat_right_safety_distance;
-  double lon_safety_distance;
+  double lat_left_safety_distance{0.};
+  double lat_right_safety_distance{0.};
+  double lon_safety_distance{0.};
   Polygon polygon;
   Polygon GetPolygon() const {
     return polygon;

--- a/bark/world/evaluation/rss/safety_polygon.hpp
+++ b/bark/world/evaluation/rss/safety_polygon.hpp
@@ -35,8 +35,12 @@ struct SafetyPolygon {
   double lat_right_safety_distance{0.};
   double lon_safety_distance{0.};
   Polygon polygon;
+  AgentId agent_id{0};
   Polygon GetPolygon() const {
     return polygon;
+  }
+  AgentId GetAgentId() const {
+    return agent_id;
   }
 };
 
@@ -92,6 +96,9 @@ inline std::ostream &operator<<(std::ostream &os, const SafetyPolygon& v)
   os << ",";
   os << "lon_safety_distance:";
   os << v.lon_safety_distance;
+  os << ",";
+  os << "agent_id:";
+  os << v.agent_id;
   os << ")";
   return os;
 }

--- a/bark/world/evaluation/rss/safety_polygon.hpp
+++ b/bark/world/evaluation/rss/safety_polygon.hpp
@@ -29,14 +29,20 @@ using objects::StateDefinition;
 using bark::geometry::SignedAngleDiff;
 namespace bg = boost::geometry;
 
-// TODO: make serializable
+/**
+ * @brief  SafetyPolygon that contains the information extracted
+ *         from the RSS interface.
+ * @note   In particular, the longitudinal and lateral safety distances,
+ *         the polygon itself, the AgentId it is associtated with.
+ * @retval None
+ */
 struct SafetyPolygon {
-  double lat_left_safety_distance{0.};
-  double lat_right_safety_distance{0.};
-  double lon_safety_distance{0.};
-  Polygon polygon;
-  AgentId agent_id{0};
-  double curr_distance{0.};
+  double lat_left_safety_distance{0.};  // lateral left safety distance
+  double lat_right_safety_distance{0.};  // lateral right safety distance
+  double lon_safety_distance{0.};  // longitudinal safety distance
+  Polygon polygon;  // BARK Polygon representing the safety area
+  AgentId agent_id{0};  // AgentId of the other agent
+  double curr_distance{0.};  // current longitudinal distance to other agent
   Polygon GetPolygon() const {
     return polygon;
   }
@@ -47,29 +53,48 @@ struct SafetyPolygon {
 
 typedef std::shared_ptr<SafetyPolygon> SafetyPolygonPtr;
 
+/**
+ * @brief  A function that computes the actual polygon within the SafetyPolygon
+ * @note   It uses the current vehicle shape and extends it with the given
+ *         safety distances. The longitudinal safety distance is drawn
+ *         conditional on whether the other vehicle is preceeding or not.
+ *         Based on the scalar values in the SafetyPolygon, it computes and
+ *         fills the BARK polygon within the SafetyPolygon struct.
+ * @param  safe_poly: SafetyPolgon 
+ * @param  observed_world: ObservedWorld of the Agent to obtain geospatial info
+ * @retval None
+ */
 inline void ComputeSafetyPolygon(
   SafetyPolygon& safe_poly, const ObservedWorld& observed_world) {
-  // 1. copy shape and insert into safe_poly
+  // 1. Get the ego agent required values
   auto ego_agent = observed_world.GetEgoAgent();
   auto ego_pose = ego_agent->GetCurrentPosition();
   auto ego_state = ego_agent->GetCurrentState();
   auto theta = ego_state(StateDefinition::THETA_POSITION);
 
-  // 2. transform
-  std::vector<Point2d> points = ego_agent->GetPolygonFromState(ego_state).obj_.outer();
+  // 2. transform the polygon of the ego agent so it includes safety distances
+  std::vector<Point2d> points =
+    ego_agent->GetPolygonFromState(ego_state).obj_.outer();
   for (auto pt : points) {
+    // angle to the point in the polygon in respect to the ego pose
     double pt_angle = atan2(
       bg::get<1>(ego_pose) - bg::get<1>(pt),
       bg::get<0>(ego_pose) - bg::get<0>(pt));
+    // if the point is on the left side it is [-pi, 0]
+    // if the point is on the right side it is [0, pi]
     double signed_angle_diff_lat = SignedAngleDiff(theta, pt_angle);
+    // here we tilt the vehicle angle pi/2 to the left so that is is
+    // perpendicular to the vehicle
+    // pt_angle smaller than zero are behing, otherwise in front
     double signed_angle_diff_lon = SignedAngleDiff(theta - M_PI_2, pt_angle);
     double sgn_lat = signed_angle_diff_lat > 0 ? 1 : -1;
     double sgn_lon = signed_angle_diff_lon > 0 ? 1 : -1;
 
-    // lateral safety distances
+    // compute lateral safety distances
     double lat_dist = 0;
     lat_dist =  sgn_lat < 0 ? safe_poly.lat_left_safety_distance : safe_poly.lat_right_safety_distance;  // NOLINT
     auto lat_proj_angle = sgn_lat < 0 ? theta - M_PI_2 : theta + M_PI_2;
+    // NOTE: often the safety distance is returned as 1+e9
     if (lat_dist < 10000) {
       auto x_new = bg::get<0>(pt) + lat_dist*cos(lat_proj_angle);
       auto y_new = bg::get<1>(pt) + lat_dist*sin(lat_proj_angle);
@@ -77,7 +102,7 @@ inline void ComputeSafetyPolygon(
       bg::set<1>(pt, y_new);
     }
 
-    // intermediate step: calculate if the agent is in front or behind
+    // calculate if the agent is in front or behind
     auto other_agent = observed_world.GetAgents()[safe_poly.agent_id];
     auto other_pose = other_agent->GetCurrentPosition();
     double relative_angle = atan2(
@@ -86,13 +111,16 @@ inline void ComputeSafetyPolygon(
     double diff_angle = SignedAngleDiff(theta - M_PI_2, relative_angle);
     double sgn_lon_in_front = diff_angle > 0 ? 1 : -1;
 
-    // if the signs are different we do not want to modify the original
-    // point of the polygon
+    // this enables directional computation for the longitudinal
+    // safety distance
+    // if the signs are different, sgn_lon is set to zero
+    // Thus, the original point of the polygon will not be modified
+    // NOTE: often the safety distance is returned as 1+e9
     if (sgn_lon_in_front*sgn_lon < 0. ||
         safe_poly.lon_safety_distance > 10000.)
       sgn_lon = 0.;
 
-    // longitudinal back and front safety distance
+    // longitudinal safety distance
     bg::set<0>(
       pt, bg::get<0>(pt) + sgn_lon*safe_poly.lon_safety_distance*cos(theta));
     bg::set<1>(

--- a/bark/world/evaluation/rss/safety_polygon.hpp
+++ b/bark/world/evaluation/rss/safety_polygon.hpp
@@ -13,7 +13,9 @@
 #include <memory>
 #include <string>
 
+#include "bark/world/world.hpp"
 #include "bark/geometry/polygon.hpp"
+#include "bark/geometry/commons.hpp"
 #include "bark/world/world.hpp"
 
 
@@ -23,6 +25,9 @@ namespace evaluation {
 
 using geometry::Polygon;
 using bark::world::AgentId;
+using objects::StateDefinition;
+using bark::geometry::SignedAngleDiff;
+namespace bg = boost::geometry;
 
 // TODO: make serializable
 struct SafetyPolygon {
@@ -36,6 +41,45 @@ struct SafetyPolygon {
 };
 
 typedef std::shared_ptr<SafetyPolygon> SafetyPolygonPtr;
+
+inline void ComputeSafetyPolygon(
+  SafetyPolygon& safe_poly, const ObservedWorld& observed_world) {
+  // 1. copy shape and insert into safe_poly
+  auto ego_agent = observed_world.GetEgoAgent();
+  auto ego_pose = ego_agent->GetCurrentPosition();
+  auto ego_state = ego_agent->GetCurrentState();
+  auto theta = ego_state(StateDefinition::THETA_POSITION);
+
+  // 2. transform
+  std::vector<Point2d> points = ego_agent->GetPolygonFromState(ego_state).obj_.outer();
+  for (auto pt : points) {
+    double pt_angle = atan2(
+      bg::get<1>(ego_pose) - bg::get<1>(pt),
+      bg::get<0>(ego_pose) - bg::get<0>(pt));
+    double signed_angle_diff_lat = SignedAngleDiff(theta, pt_angle);
+    double signed_angle_diff_lon = SignedAngleDiff(theta - 3.14/2., pt_angle);
+    double sgn_lat = signed_angle_diff_lat > 0 ? 1 : -1;
+    double sgn_lon = signed_angle_diff_lon > 0 ? 1 : -1;
+
+    // lateral safety distancesa
+    double lat_dist = 0;
+    lat_dist =  sgn_lat < 0 ? safe_poly.lat_left_safety_distance : safe_poly.lat_right_safety_distance;  // NOLINT
+    auto lat_proj_angle = sgn_lat > 0 ? theta - 3.14/2. : theta + 3.14/2.;
+    if (sgn_lat < 0) {
+      auto x_new = bg::get<0>(pt) + lat_dist*cos(lat_proj_angle);
+      auto y_new = bg::get<1>(pt) + lat_dist*sin(lat_proj_angle);
+      bg::set<0>(pt, x_new);
+      bg::set<1>(pt, y_new);
+    }
+
+    // longitudinal back and front safety distance
+    bg::set<0>(
+      pt, bg::get<0>(pt) + sgn_lon*safe_poly.lon_safety_distance*cos(theta));
+    bg::set<1>(
+      pt, bg::get<1>(pt) + sgn_lon*safe_poly.lon_safety_distance*sin(theta));
+    safe_poly.polygon.AddPoint(pt);
+  }
+}
 
 inline std::ostream &operator<<(std::ostream &os, const SafetyPolygon& v)
 {

--- a/bark/world/evaluation/rss/safety_polygon.hpp
+++ b/bark/world/evaluation/rss/safety_polygon.hpp
@@ -30,10 +30,24 @@ struct SafetyPolygon {
   double lat_right_safety_distance;
   double lon_safety_distance;
   Polygon polygon;
-  AgentId from_id, to_id;
 };
 
 typedef std::shared_ptr<SafetyPolygon> SafetyPolygonPtr;
+
+inline std::ostream &operator<<(std::ostream &os, const SafetyPolygon& v)
+{
+  os << "SafetyPolygon(";
+  os << "lat_left_safety_distance:";
+  os << v.lat_left_safety_distance;
+  os << ",";
+  os << "lat_right_safety_distance:";
+  os << v.lat_right_safety_distance;
+  os << ",";
+  os << "lon_safety_distance:";
+  os << v.lon_safety_distance;
+  os << ")";
+  return os;
+}
 
 }  // namespace evaluation
 }  // namespace world

--- a/bark/world/evaluation/rss/safety_polygon.hpp
+++ b/bark/world/evaluation/rss/safety_polygon.hpp
@@ -30,6 +30,9 @@ struct SafetyPolygon {
   double lat_right_safety_distance;
   double lon_safety_distance;
   Polygon polygon;
+  Polygon GetPolygon() const {
+    return polygon;
+  }
 };
 
 typedef std::shared_ptr<SafetyPolygon> SafetyPolygonPtr;

--- a/bark/world/evaluation/rss/safety_polygon.hpp
+++ b/bark/world/evaluation/rss/safety_polygon.hpp
@@ -36,6 +36,7 @@ struct SafetyPolygon {
   double lon_safety_distance{0.};
   Polygon polygon;
   AgentId agent_id{0};
+  double curr_distance{0.};
   Polygon GetPolygon() const {
     return polygon;
   }
@@ -99,6 +100,9 @@ inline std::ostream &operator<<(std::ostream &os, const SafetyPolygon& v)
   os << ",";
   os << "agent_id:";
   os << v.agent_id;
+  os << ",";
+  os << "curr_distance:";
+  os << v.curr_distance;
   os << ")";
   return os;
 }


### PR DESCRIPTION
* Extension of the ScenarioDumper. It is now possible to specify config_ids
* Drawing of SafetyPolygons that contain the lateral and longitudinal safety distances, as well as other additional information
* Python-bindings for the SafetyPolygon
* Modification of the RSSViewer to plot the SafetyPolygons
* Modification of the RSSEvaluator to store additional data
* New interfaces for the RSSEvaluator, SafetyPolygon, and BehaviorRSSConformant
* Created and extended the serialization of SafetyPolygon and BehaviorRSSConformant

