### PR TITLE
Fix Rss-Evaluator

### DIFF
--- a/bark/models/behavior/idm/idm_lane_tracking.cpp
+++ b/bark/models/behavior/idm/idm_lane_tracking.cpp
@@ -97,9 +97,9 @@ std::tuple<Trajectory, Action> BehaviorIDMLaneTracking::GenerateTrajectory(
 
       double acc_lat = CalculateLateralAcceleration(
           single_track, angle, traj(i, StateDefinition::VEL_POSITION));
-      VLOG(4) << "Plan(i=" << i << "): LonAcc:  " << acc << ", "
-              << "LatAcc: " << acc_lat << ", "
-              << GetAccelerationLimits();
+      // VLOG(4) << "Plan(i=" << i << "): LonAcc:  " << acc << ", "
+      //         << "LatAcc: " << acc_lat << ", "
+      //         << GetAccelerationLimits();
       CheckAccelerationLimits(acc, acc_lat);
     }
   }

--- a/bark/world/evaluation/rss/rss_interface.cpp
+++ b/bark/world/evaluation/rss/rss_interface.cpp
@@ -355,9 +355,8 @@ bool RssInterface::RssCheck(
   // rss_state_snapshot: individual situation responses calculated from
   // SituationSnapshot
   bool result = rss_check.calculateProperResponse(
-      world_model, situation_snapshot, rss_state_snapshot_,
+      world_model, situation_snapshot, rss_state_snapshot,
       rss_proper_response_);
-
   if (!result) {
     LOG(ERROR) << "Failed to perform RSS check" << std::endl;
   }
@@ -441,6 +440,7 @@ EvaluationReturn RssInterface::GetSafetyReponse(
   if (GenerateRSSWorld(observed_world, rss_world)) {
     ::ad::rss::state::RssStateSnapshot snapshot;
     RssCheck(rss_world, snapshot);
+    rss_state_snapshot_ = snapshot;
     response = ExtractSafetyEvaluation(snapshot);
   }
   return response;
@@ -453,6 +453,7 @@ PairwiseEvaluationReturn RssInterface::GetPairwiseSafetyReponse(
   if (GenerateRSSWorld(observed_world, rss_world)) {
     ::ad::rss::state::RssStateSnapshot snapshot;
     RssCheck(rss_world, snapshot);
+    rss_state_snapshot_ = snapshot;
     response = ExtractPairwiseSafetyEvaluation(snapshot);
   }
   return response;

--- a/bark/world/evaluation/rss/safety_polygon.hpp
+++ b/bark/world/evaluation/rss/safety_polygon.hpp
@@ -93,7 +93,7 @@ inline void ComputeSafetyPolygon(
     // compute lateral safety distances
     double lat_dist = 0;
     lat_dist =  sgn_lat < 0 ? safe_poly.lat_left_safety_distance : safe_poly.lat_right_safety_distance;  // NOLINT
-    auto lat_proj_angle = sgn_lat < 0 ? theta - M_PI_2 : theta + M_PI_2;
+    auto lat_proj_angle = sgn_lat > 0 ? theta - M_PI_2 : theta + M_PI_2;
     // NOTE: often the safety distance is returned as 1+e9
     if (lat_dist < 10000) {
       auto x_new = bg::get<0>(pt) + lat_dist*cos(lat_proj_angle);


### PR DESCRIPTION
The RssCheck needs an empty RssStateSnapshot. Otherwise the safety maneuver is not triggered.