### PR TITLE
MinRssBrakingDistance for all Vehicles and Fixed ComputeSafetyPolygon

### DIFF
--- a/bark/python_wrapper/world/evaluation.cpp
+++ b/bark/python_wrapper/world/evaluation.cpp
@@ -19,6 +19,7 @@
 #include "bark/python_wrapper/world/ltl.hpp"
 #include "bark/world/evaluation/rss/safety_polygon.hpp"
 #ifdef RSS
+#include "bark/world/evaluation/rss/commons.hpp"
 #include "bark/world/evaluation/rss/evaluator_rss.hpp"
 #endif
 
@@ -127,6 +128,7 @@ void python_evaluation(py::module m) {
       .def("__repr__", [](const EvaluatorRSS& g) {
         return "bark.core.world.evaluation.EvaluatorRSS";
       });
+  m.def("ComputeMinBrakingPolygon", &ComputeMinBrakingPolygon);
 #endif
 
   m.def("CaptureAgentStates",

--- a/bark/runtime/viewer/viewer.py
+++ b/bark/runtime/viewer/viewer.py
@@ -88,7 +88,7 @@ class BaseViewer(Viewer):
           "Flag to specify if visualizating rss safety responses.",
           False]
         self._rss_min_braking_distances = params["Visualization"]["Evaluation"][
-          "DrawMinRSSBrakingDistanced",
+          "DrawMinRSSBrakingDistances",
           "Flag whether the min. braking distances shall be plotted.",
           False]
         

--- a/bark/runtime/viewer/viewer.py
+++ b/bark/runtime/viewer/viewer.py
@@ -90,7 +90,7 @@ class BaseViewer(Viewer):
         self._rss_min_braking_distances = params["Visualization"]["Evaluation"][
           "DrawMinRSSBrakingDistanced",
           "Flag whether the min. braking distances shall be plotted.",
-          True]
+          False]
         
         self.parameters = params
         self.agent_color_map = {}

--- a/bark/runtime/viewer/viewer.py
+++ b/bark/runtime/viewer/viewer.py
@@ -497,8 +497,11 @@ class BaseViewer(Viewer):
           rss_params = self.parameters["EvaluatorRss"]["Ego"]
         else:
           rss_params = self.parameters["EvaluatorRss"]["Others"]
-        min_braking_safety_polygon = ComputeMinBrakingPolygon(observed_world, rss_params)
-        color_face = "red" # self.agent_color_map[agent_id]
+        try:
+          min_braking_safety_polygon = ComputeMinBrakingPolygon(observed_world, rss_params)
+        except:
+          pass
+        color_face = "red"
         self.drawPolygon2d(
           min_braking_safety_polygon.GetPolygon(), color_face, 0.25, color_face, zorder=9)
         

--- a/bark/runtime/viewer/viewer.py
+++ b/bark/runtime/viewer/viewer.py
@@ -16,6 +16,7 @@ from bark.core.world.goal_definition import *
 from bark.runtime.commons.parameters import ParameterServer
 import math
 from bark.core.world.evaluation.ltl import *
+from bark.core.world.evaluation import *
 from bark.core.models.behavior import *
 
 logger = logging.getLogger()
@@ -86,7 +87,11 @@ class BaseViewer(Viewer):
           "DrawEgoRSSSafetyResponses",
           "Flag to specify if visualizating rss safety responses.",
           False]
-
+        self._rss_min_braking_distances = params["Visualization"]["Evaluation"][
+          "DrawMinRSSBrakingDistanced",
+          "Flag whether the min. braking distances shall be plotted.",
+          True]
+        
         self.parameters = params
         self.agent_color_map = {}
         self.max_agents_color_map = 0
@@ -347,7 +352,7 @@ class BaseViewer(Viewer):
               self.drawBehaviorPlan(eval_agent)
         
         if self._draw_ego_rss_safety_responses:
-          self.DrawRSSEvaluatorState(world, eval_agent_ids[0])
+          self.DrawRSSEvaluatorState(world, eval_agent_ids[0], eval_agent_ids[0])
 
     def drawMapAerialImage(self):
         pass
@@ -481,9 +486,22 @@ class BaseViewer(Viewer):
             self.drawPolygon2d(transformed_polygon, response_color,
                                0.6, response_color, zorder=9)
 
-    def DrawRSSEvaluatorState(self, world, agent_id):
+    def DrawRSSEvaluatorState(self, world, agent_id, eval_id):
       agent = world.agents[agent_id]
       behavior = agent.behavior_model
+      
+      if self._rss_min_braking_distances:
+        for agent_id, agent in world.agents.items():
+          observed_world = world.Observe([agent_id])[0]
+          rss_params = None
+          if eval_id == agent_id:
+            rss_params = self.parameters["EvaluatorRss"]["Ego"]
+          else:
+            rss_params = self.parameters["EvaluatorRss"]["Others"]
+          min_braking_safety_polygon = ComputeMinBrakingPolygon(observed_world, rss_params)
+          color_face = "red" # self.agent_color_map[agent_id]
+          self.drawPolygon2d(min_braking_safety_polygon.GetPolygon(), color_face, 0.25, color_face, zorder=9)
+        
       if isinstance(behavior, BehaviorRSSConformant):
         longitudinal_response = behavior.GetLongitudinalResponse()
         lateral_left_response = behavior.GetLateralLeftResponse()
@@ -500,7 +518,7 @@ class BaseViewer(Viewer):
         observed_world = world.Observe([agent_id])[0]
         behavior.ComputeSafetyPolygons(observed_world)
         safety_polygons = behavior.GetSafetyPolygons()
-        
+    
         for poly in safety_polygons:
           print(poly)
           color_face = self.agent_color_map[poly.GetAgentId()]

--- a/bark/world/evaluation/rss/BUILD
+++ b/bark/world/evaluation/rss/BUILD
@@ -5,7 +5,7 @@ cc_library(
         "//conditions:default": [],
     }),
     hdrs = select({
-        "//bark/world/evaluation/rss:_rss": ["rss_interface.hpp"],
+        "//bark/world/evaluation/rss:_rss": ["rss_interface.hpp", "commons.hpp"],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
@@ -43,6 +43,7 @@ cc_library(
         ":safety_polygon"
     ]
 )
+
 
 config_setting(
     name = "_rss",

--- a/bark/world/evaluation/rss/commons.hpp
+++ b/bark/world/evaluation/rss/commons.hpp
@@ -94,7 +94,7 @@ inline SafetyPolygon ComputeMinBrakingPolygon(
 
   // compute actual BARK polygon
   ComputeSafetyPolygon(
-    safety_poly, observed_world);
+    safety_poly, observed_world, LonDirectionMode::FRONT);
 
   return safety_poly;
 } 

--- a/bark/world/evaluation/rss/commons.hpp
+++ b/bark/world/evaluation/rss/commons.hpp
@@ -36,9 +36,12 @@ using ad::physics::Duration;
 using bark::commons::transformation::FrenetState;
 
 /**
- * @brief  Calculates the min. braking distance of an agent
+ * @brief  Calculates the min. braking distance for an agent
  * @note   
- * @retval 
+ * @param  observed_world: ObservedWorld for which the braking distance
+ *                         should be dran
+ * @param  rss_params:  RSSDynamics either for ego ot others
+ * @retval SafetyPolygon
  */
 inline SafetyPolygon ComputeMinBrakingPolygon(
   const ObservedWorld& observed_world, const commons::ParamsPtr& rss_params) {

--- a/bark/world/evaluation/rss/commons.hpp
+++ b/bark/world/evaluation/rss/commons.hpp
@@ -1,0 +1,107 @@
+// Copyright (c) 2020 fortiss GmbH
+//
+// Authors: Julian Bernhard, Klemens Esterle, Patrick Hart and
+// Tobias Kessler
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#ifndef BARK_WORLD_EVALUATION_COMMONS_HPP_
+#define BARK_WORLD_EVALUATION_COMMONS_HPP_
+
+#include <limits>
+#include <memory>
+#include <string>
+
+#include "bark/world/world.hpp"
+#include "bark/geometry/polygon.hpp"
+#include "bark/geometry/commons.hpp"
+#include "bark/commons/transformation/frenet.hpp"
+#include "bark/world/evaluation/rss/safety_polygon.hpp"
+
+#include <ad/rss/situation/Physics.hpp>
+#include <ad/rss/situation/RssFormulas.hpp>
+
+namespace bark {
+namespace world {
+namespace evaluation {
+
+using geometry::Polygon;
+// using ::ad::rss::situation::calculateLongitudinalDistanceOffsetAfterStatedBrakingPattern;
+// using ::ad::rss::situation::calculateLateralDistanceOffsetAfterStatedBrakingPattern;
+using ad::physics::Distance;
+using ad::physics::Acceleration;
+using ad::physics::Duration;
+using bark::commons::transformation::FrenetState;
+
+/**
+ * @brief  Calculates the min. braking distance of an agent
+ * @note   
+ * @retval 
+ */
+inline SafetyPolygon ComputeMinBrakingPolygon(
+  const ObservedWorld& observed_world, const commons::ParamsPtr& rss_params) {
+  auto agent = observed_world.GetEgoAgent();
+  auto state = agent.GetCurrentState();
+  auto lane_corr = observed_world.GetLaneCorridor();
+  auto center_line = lane_corr->GetCenterLine();
+
+  // calculate vlon and vlat
+  FrenetState frenet_state(state, center_line);
+
+  // parameters
+  Distance min_stopping_distance_lon;
+  Acceleration accel_max_lon = Acceleration(
+    params->GetReal("BrakeLonMax", "maximum deceleration", -1.7));
+  Acceleration brake_min_correct_lon = Acceleration(params->GetReal(
+    "BrakeLonMinCorrect", "minimum deceleration of oncoming vehicle", -1.67));
+  Duration response_time = Duration(
+    rss_params->GetReal("TimeResponse", "response time of the ego vehicle", 0.2));
+  Distance min_stopping_distance_lat;
+  Acceleration accel_max_lat = Acceleration(
+    params->GetReal("AccLatBrakeMax", "maximum lateral acceleration", 0.2));
+  Acceleration brake_min_correct_lat = Acceleration(
+    params->GetReal("AccLatBrakeMin", "minimum lateral braking", -0.8));
+
+  // longitudinal min braking distance
+  auto const lon_result = calculateLongitudinalDistanceOffsetAfterStatedBrakingPattern(
+    frenet_state.vlon,
+    physics::Speed::getMax(),
+    response_time,
+    accel_max_lon,
+    brake_min_correct_lon,
+    min_stopping_distance_lon);
+  
+  // lateral min braking distance
+  auto const lat_result = calculateLateralDistanceOffsetAfterStatedBrakingPattern(
+    frenet_state.vlat,
+    response_time,
+    accel_max_lat,
+    brake_min_correct_lat,
+    min_stopping_distance_lat);
+  
+
+  // fill longitdunial and lateral values
+  SafetyPolygon safety_poly;
+
+  // if the distances could not be calculated
+  if (!lon_result || !lat_result);
+    return safety_poly;
+  
+  safety_poly.lat_left_safety_distance = min_stopping_distance_lat;
+  safety_poly.lat_right_safety_distance = min_stopping_distance_lat;
+  safety_poly.lon_safety_distance = min_stopping_distance_lon;
+
+  // compute actual BARK polygon
+  ComputeSafetyPolygon(
+    safety_poly, observed_world);
+
+  return safety_poly;
+} 
+
+
+}  // namespace evaluation
+}  // namespace world
+}  // namespace bark
+
+#endif  // BARK_WORLD_EVALUATION_COMMONS_HPP_

--- a/bark/world/evaluation/rss/commons.hpp
+++ b/bark/world/evaluation/rss/commons.hpp
@@ -85,7 +85,7 @@ inline SafetyPolygon ComputeMinBrakingPolygon(
   SafetyPolygon safety_poly;
 
   // if the distances could not be calculated
-  if (!lon_result || !lat_result);
+  if (!lon_result || !lat_result)
     return safety_poly;
   
   safety_poly.lat_left_safety_distance = min_stopping_distance_lat;

--- a/bark/world/evaluation/rss/commons.hpp
+++ b/bark/world/evaluation/rss/commons.hpp
@@ -17,6 +17,7 @@
 #include "bark/geometry/polygon.hpp"
 #include "bark/geometry/commons.hpp"
 #include "bark/commons/transformation/frenet.hpp"
+#include "bark/commons/transformation/frenet_state.hpp"
 #include "bark/world/evaluation/rss/safety_polygon.hpp"
 
 #include <ad/rss/situation/Physics.hpp>
@@ -27,8 +28,8 @@ namespace world {
 namespace evaluation {
 
 using geometry::Polygon;
-// using ::ad::rss::situation::calculateLongitudinalDistanceOffsetAfterStatedBrakingPattern;
-// using ::ad::rss::situation::calculateLateralDistanceOffsetAfterStatedBrakingPattern;
+using ::ad::rss::situation::calculateLongitudinalDistanceOffsetAfterStatedBrakingPattern;
+using ::ad::rss::situation::calculateLateralDistanceOffsetAfterStatedBrakingPattern;
 using ad::physics::Distance;
 using ad::physics::Acceleration;
 using ad::physics::Duration;
@@ -42,7 +43,7 @@ using bark::commons::transformation::FrenetState;
 inline SafetyPolygon ComputeMinBrakingPolygon(
   const ObservedWorld& observed_world, const commons::ParamsPtr& rss_params) {
   auto agent = observed_world.GetEgoAgent();
-  auto state = agent.GetCurrentState();
+  auto state = agent->GetCurrentState();
   auto lane_corr = observed_world.GetLaneCorridor();
   auto center_line = lane_corr->GetCenterLine();
 
@@ -52,21 +53,21 @@ inline SafetyPolygon ComputeMinBrakingPolygon(
   // parameters
   Distance min_stopping_distance_lon;
   Acceleration accel_max_lon = Acceleration(
-    params->GetReal("BrakeLonMax", "maximum deceleration", -1.7));
-  Acceleration brake_min_correct_lon = Acceleration(params->GetReal(
+    rss_params->GetReal("BrakeLonMax", "maximum deceleration", -1.7));
+  Acceleration brake_min_correct_lon = Acceleration(rss_params->GetReal(
     "BrakeLonMinCorrect", "minimum deceleration of oncoming vehicle", -1.67));
   Duration response_time = Duration(
     rss_params->GetReal("TimeResponse", "response time of the ego vehicle", 0.2));
   Distance min_stopping_distance_lat;
   Acceleration accel_max_lat = Acceleration(
-    params->GetReal("AccLatBrakeMax", "maximum lateral acceleration", 0.2));
+    rss_params->GetReal("AccLatBrakeMax", "maximum lateral acceleration", 0.2));
   Acceleration brake_min_correct_lat = Acceleration(
-    params->GetReal("AccLatBrakeMin", "minimum lateral braking", -0.8));
+    rss_params->GetReal("AccLatBrakeMin", "minimum lateral braking", -0.8));
 
   // longitudinal min braking distance
   auto const lon_result = calculateLongitudinalDistanceOffsetAfterStatedBrakingPattern(
     frenet_state.vlon,
-    physics::Speed::getMax(),
+    ad::physics::Speed::getMax(),
     response_time,
     accel_max_lon,
     brake_min_correct_lon,
@@ -80,7 +81,6 @@ inline SafetyPolygon ComputeMinBrakingPolygon(
     brake_min_correct_lat,
     min_stopping_distance_lat);
   
-
   // fill longitdunial and lateral values
   SafetyPolygon safety_poly;
 

--- a/bark/world/evaluation/rss/safety_polygon.hpp
+++ b/bark/world/evaluation/rss/safety_polygon.hpp
@@ -112,7 +112,6 @@ inline void ComputeSafetyPolygon(
         bg::get<0>(ego_pose) - bg::get<0>(other_pose));
       double diff_angle = SignedAngleDiff(theta - M_PI_2, relative_angle);
       double sgn_lon_in_front = diff_angle > 0 ? 1 : -1;
-      }
       // this enables directional computation for the longitudinal
       // safety distance
       // if the signs are different, sgn_lon is set to zero

--- a/bark/world/evaluation/rss/safety_polygon.hpp
+++ b/bark/world/evaluation/rss/safety_polygon.hpp
@@ -53,6 +53,12 @@ struct SafetyPolygon {
 
 typedef std::shared_ptr<SafetyPolygon> SafetyPolygonPtr;
 
+enum LonDirectionMode {
+  AUTO = 0,
+  FRONT = 1,
+  BEHIND = 2
+};
+
 /**
  * @brief  A function that computes the actual polygon within the SafetyPolygon
  * @note   It uses the current vehicle shape and extends it with the given
@@ -66,7 +72,7 @@ typedef std::shared_ptr<SafetyPolygon> SafetyPolygonPtr;
  */
 inline void ComputeSafetyPolygon(
   SafetyPolygon& safe_poly, const ObservedWorld& observed_world, 
-  bool directional = true) {
+  LonDirectionMode directional = LonDirectionMode::AUTO) {
   // 1. Get the ego agent required values
   auto ego_agent = observed_world.GetEgoAgent();
   auto ego_pose = ego_agent->GetCurrentPosition();
@@ -103,7 +109,7 @@ inline void ComputeSafetyPolygon(
       bg::set<1>(pt, y_new);
     }
 
-    if (directional) {
+    if (directional == LonDirectionMode::AUTO) {
       // calculate if the agent is in front or behind
       auto other_agent = observed_world.GetAgents()[safe_poly.agent_id];
       auto other_pose = other_agent->GetCurrentPosition();
@@ -119,6 +125,12 @@ inline void ComputeSafetyPolygon(
       // NOTE: often the safety distance is returned as 1+e9
       if (sgn_lon_in_front*sgn_lon < 0.)
         sgn_lon = 0.;
+    } else if(directional == LonDirectionMode::FRONT) {
+      if (sgn_lon < 0.)
+        sgn_lon = 0;
+    } else if(directional == LonDirectionMode::BEHIND) {
+      if (sgn_lon > 0.)
+        sgn_lon = 0;
     }
 
     // if too large number

--- a/bark/world/evaluation/rss/safety_polygon.hpp
+++ b/bark/world/evaluation/rss/safety_polygon.hpp
@@ -75,6 +75,9 @@ inline void ComputeSafetyPolygon(
   LonDirectionMode directional = LonDirectionMode::AUTO) {
   // 1. Get the ego agent required values
   auto ego_agent = observed_world.GetEgoAgent();
+  if (!ego_agent)
+    return safe_poly;
+  
   auto ego_pose = ego_agent->GetCurrentPosition();
   auto ego_state = ego_agent->GetCurrentState();
   auto theta = ego_state(StateDefinition::THETA_POSITION);

--- a/bark/world/evaluation/rss/safety_polygon.hpp
+++ b/bark/world/evaluation/rss/safety_polygon.hpp
@@ -53,10 +53,16 @@ struct SafetyPolygon {
 
 typedef std::shared_ptr<SafetyPolygon> SafetyPolygonPtr;
 
+/**
+ * @brief  Modes for drawing the longitudinal visualization
+ * @note   
+ * @retval None
+ */
 enum LonDirectionMode {
   AUTO = 0,
   FRONT = 1,
-  BEHIND = 2
+  BEHIND = 2,
+  FRONT_BEHIND = 3
 };
 
 /**
@@ -112,6 +118,7 @@ inline void ComputeSafetyPolygon(
       bg::set<1>(pt, y_new);
     }
 
+    // draws the polygon in relation to the other agent
     if (directional == LonDirectionMode::AUTO) {
       // calculate if the agent is in front or behind
       auto other_agent = observed_world.GetAgents()[safe_poly.agent_id];
@@ -130,15 +137,17 @@ inline void ComputeSafetyPolygon(
       // NOTE: often the safety distance is returned as 1+e9
       if (sgn_lon_in_front*sgn_lon < 0.)
         sgn_lon = 0.;
-    } else if(directional == LonDirectionMode::FRONT) {
+    } else if(directional == LonDirectionMode::FRONT) { 
+      // draws the polygon only in the front
       if (sgn_lon < 0.)
         sgn_lon = 0;
     } else if(directional == LonDirectionMode::BEHIND) {
+      // draws the polygon only behind
       if (sgn_lon > 0.)
         sgn_lon = 0;
     }
 
-    // if too large number
+    // if number is too large
     if (safe_poly.lon_safety_distance > 10000.)
       sgn_lon = 0;
     

--- a/bark/world/evaluation/rss/safety_polygon.hpp
+++ b/bark/world/evaluation/rss/safety_polygon.hpp
@@ -76,7 +76,7 @@ inline void ComputeSafetyPolygon(
   // 1. Get the ego agent required values
   auto ego_agent = observed_world.GetEgoAgent();
   if (!ego_agent)
-    return safe_poly;
+    return;
   
   auto ego_pose = ego_agent->GetCurrentPosition();
   auto ego_state = ego_agent->GetCurrentState();

--- a/bark/world/evaluation/rss/safety_polygon.hpp
+++ b/bark/world/evaluation/rss/safety_polygon.hpp
@@ -115,6 +115,8 @@ inline void ComputeSafetyPolygon(
     if (directional == LonDirectionMode::AUTO) {
       // calculate if the agent is in front or behind
       auto other_agent = observed_world.GetAgents()[safe_poly.agent_id];
+      if (!other_agent)
+        return;
       auto other_pose = other_agent->GetCurrentPosition();
       double relative_angle = atan2(
         bg::get<1>(ego_pose) - bg::get<1>(other_pose),


### PR DESCRIPTION
* Fixes segfault issue with `ComputeSafetyPolygon` when the other agent has already been deleted
* Implements a calculation function for the minimum braking distance of an agent `ComputeMinBrakingPolygon`
* Modified viewer that draws all the braking distances using the flag `params["Visualization"]["Evaluation"]["DrawMinRSSBrakingDistances"] = True`