### PR TITLE
Change LaneCorridor selection in BaseIDM

### DIFF
--- a/bark/models/behavior/behavior_rss/behavior_rss.cpp
+++ b/bark/models/behavior/behavior_rss/behavior_rss.cpp
@@ -104,7 +104,7 @@ Trajectory BehaviorRSSConformant::Plan(
     LOG(INFO) << "Executing safety behavior." << std::endl;
 #ifdef RSS
     if (acc_restrictions_for_safety_) {
-      ApplyRestrictionsToModel(GetAccelerationLimits(), behavior_safety_model_);
+      ApplyRestrictionsToModel(GetAccelerationLimits(), behavior_safety_model_->GetBehaviorModel());
     }
 #endif
     behavior_safety_model_->Plan(min_planning_time, observed_world);

--- a/bark/models/behavior/idm/BUILD
+++ b/bark/models/behavior/idm/BUILD
@@ -9,6 +9,7 @@ cc_library(
     deps = [
         "//bark/commons:commons",
         "//bark/world:world",
+        "//bark/world/map:commons",
         "//bark/models/dynamic:dynamic",
         "//bark/commons/transformation:frenet",
     ],

--- a/bark/models/behavior/idm/base_idm.cpp
+++ b/bark/models/behavior/idm/base_idm.cpp
@@ -369,6 +369,8 @@ Trajectory BaseIDM::Plan(double min_planning_time,
 
   LaneCorridorPtr current_lane_corridor;
   if (constant_lane_corr_ != nullptr) {
+    // decides which lane corridor to use if the agent' shape
+    // is in multiple lane corridors
     auto corrected_lane_corr = ChooseLaneCorridorBasedOnVehicleState(
       observed_world, constant_lane_corr_);
     current_lane_corridor = corrected_lane_corr;

--- a/bark/models/behavior/idm/base_idm.cpp
+++ b/bark/models/behavior/idm/base_idm.cpp
@@ -369,16 +369,9 @@ Trajectory BaseIDM::Plan(double min_planning_time,
 
   LaneCorridorPtr current_lane_corridor;
   if (constant_lane_corr_ != nullptr) {
-    // Tobias: 	
-    // GenerateTrajectory uses lane_corr_
-    // CalcRelativeValues uses current_lane_corridor
-
-    // postulate: we need only to modify: current_lane_corridor
-
-    
-    // LaneCorridor ChooseLaneCorridorBasedOnVehicleState(observed_world)
-    // TODO: set current_lane_corridor
-    current_lane_corridor = constant_lane_corr_;
+    auto corrected_lane_corr = ChooseLaneCorridorBasedOnVehicleState(
+      observed_world, constant_lane_corr_);
+    current_lane_corridor = corrected_lane_corr;
   } else {
     current_lane_corridor = lane_corr_;
   }

--- a/bark/models/behavior/idm/base_idm.cpp
+++ b/bark/models/behavior/idm/base_idm.cpp
@@ -17,6 +17,7 @@
 
 #include "bark/commons/transformation/frenet.hpp"
 #include "bark/world/observed_world.hpp"
+#include "bark/world/map/commons.hpp"
 
 namespace bark {
 namespace models {
@@ -368,6 +369,15 @@ Trajectory BaseIDM::Plan(double min_planning_time,
 
   LaneCorridorPtr current_lane_corridor;
   if (constant_lane_corr_ != nullptr) {
+    // Tobias: 	
+    // GenerateTrajectory uses lane_corr_
+    // CalcRelativeValues uses current_lane_corridor
+
+    // postulate: we need only to modify: current_lane_corridor
+
+    
+    // LaneCorridor ChooseLaneCorridorBasedOnVehicleState(observed_world)
+    // TODO: set current_lane_corridor
     current_lane_corridor = constant_lane_corr_;
   } else {
     current_lane_corridor = lane_corr_;

--- a/bark/models/behavior/idm/base_idm.cpp
+++ b/bark/models/behavior/idm/base_idm.cpp
@@ -31,7 +31,8 @@ using bark::world::map::LaneCorridorPtr;
 using bark::world::objects::Agent;
 using bark::world::objects::AgentPtr;
 
-BaseIDM::BaseIDM(const commons::ParamsPtr& params) : BehaviorModel(params) {
+BaseIDM::BaseIDM(const commons::ParamsPtr& params)
+    : BehaviorModel(params), constant_lane_corr_(nullptr) {
   param_minimum_spacing_ = params->GetReal("BehaviorIDMClassic::MinimumSpacing",
                                            "See Wikipedia IDM article", 2.0);
   param_desired_time_head_way_ =
@@ -39,9 +40,8 @@ BaseIDM::BaseIDM(const commons::ParamsPtr& params) : BehaviorModel(params) {
                       "See Wikipedia IDM article", 1.5);
   param_max_acceleration_ = params->GetReal(
       "BehaviorIDMClassic::MaxAcceleration", "See Wikipedia IDM article", 1.7);
-  param_desired_velocity_ =
-      params->GetReal("BehaviorIDMClassic::DesiredVelocity",
-                      "See Wikipedia IDM article", 15.0);
+  param_desired_velocity_ = params->GetReal(
+      "BehaviorIDMClassic::DesiredVelocity", "See Wikipedia IDM article", 15.0);
   param_comfortable_braking_acceleration_ =
       params->GetReal("BehaviorIDMClassic::ComfortableBrakingAcceleration",
                       "See Wikipedia IDM article", 1.67f);
@@ -110,7 +110,8 @@ double BaseIDM::CalcInteractionTerm(double net_distance, double vel_ego,
 
 double BaseIDM::CalcNetDistance(
     const world::ObservedWorld& observed_world,
-    const std::shared_ptr<const Agent>& leading_agent) const {
+    const std::shared_ptr<const Agent>& leading_agent,
+    const LaneCorridorPtr& local_lane_corr) const {
   const auto& ego_agent = observed_world.GetEgoAgent();
   // relative velocity and longitudinal distance
   const State ego_state = ego_agent->GetCurrentState();
@@ -123,7 +124,7 @@ double BaseIDM::CalcNetDistance(
 
   // we need to use the lane corridor of the ego agent to be able to compare the
   // frenet values
-  const auto& lane_corridor = observed_world.GetLaneCorridor();
+  const auto& lane_corridor = local_lane_corr;
   FrenetPosition frenet_leading(leading_agent->GetCurrentPosition(),
                                 lane_corridor->GetCenterLine());
 
@@ -184,7 +185,7 @@ IDMRelativeValues BaseIDM::CalcRelativeValues(
 
   // vehicles
   if (leading_vehicle.first) {
-    leading_distance = CalcNetDistance(observed_world, leading_vehicle.first);
+    leading_distance = CalcNetDistance(observed_world, leading_vehicle.first, lane_corr);
     dynamic::State other_vehicle_state =
         leading_vehicle.first->GetCurrentState();
     leading_velocity = other_vehicle_state(StateDefinition::VEL_POSITION);
@@ -237,8 +238,7 @@ IDMRelativeValues BaseIDM::CalcRelativeValues(
     ego_acc = boost::get<Input>(ego_action)(0);
   } else {
     LOG(FATAL) << "ego action type unknown: "
-                << boost::apply_visitor(action_tostring_visitor(),
-                                        ego_action);
+               << boost::apply_visitor(action_tostring_visitor(), ego_action);
   }
 
   rel_values.leading_distance = leading_distance;
@@ -366,7 +366,15 @@ Trajectory BaseIDM::Plan(double min_planning_time,
     return GetLastTrajectory();
   }
 
-  IDMRelativeValues rel_values = CalcRelativeValues(observed_world, lane_corr_);
+  LaneCorridorPtr current_lane_corridor;
+  if (constant_lane_corr_ != nullptr) {
+    current_lane_corridor = constant_lane_corr_;
+  } else {
+    current_lane_corridor = lane_corr_;
+  }
+
+  IDMRelativeValues rel_values =
+      CalcRelativeValues(observed_world, current_lane_corridor);
 
   double dt = min_planning_time / (GetNumTrajectoryTimePoints() - 1);
   std::tuple<Trajectory, Action> traj_action =

--- a/bark/models/behavior/idm/base_idm.hpp
+++ b/bark/models/behavior/idm/base_idm.hpp
@@ -54,7 +54,8 @@ class BaseIDM : virtual public BehaviorModel {
                              const double vel_other) const;
   double CalcNetDistance(
       const world::ObservedWorld& observed_world,
-      const std::shared_ptr<const world::objects::Agent>& leading_agent) const;
+      const std::shared_ptr<const world::objects::Agent>& leading_agent,
+      const LaneCorridorPtr& local_lane_corr) const;
 
   std::pair<bool, double> GetDistanceToLaneEnding(
       const LaneCorridorPtr& lane_corr, const Point2d& pos) const;
@@ -121,6 +122,10 @@ class BaseIDM : virtual public BehaviorModel {
     acceleration_limits_ = acc_lim; 
   }
 
+  void SetConstantLaneCorridor(const LaneCorridorPtr& lc) {
+    constant_lane_corr_ = lc;
+  }
+
  protected:
   // Parameters
   double param_minimum_spacing_;
@@ -134,6 +139,7 @@ class BaseIDM : virtual public BehaviorModel {
   int param_exponent_;
   int num_trajectory_time_points_;
   LaneCorridorPtr lane_corr_;
+  LaneCorridorPtr constant_lane_corr_;
 
   // IDM extension to stop at the end of the LaneCorridor
   bool brake_lane_end_;

--- a/bark/models/behavior/idm/idm_lane_tracking.hpp
+++ b/bark/models/behavior/idm/idm_lane_tracking.hpp
@@ -27,8 +27,7 @@ class BehaviorIDMLaneTracking : public BaseIDM {
   explicit BehaviorIDMLaneTracking(const commons::ParamsPtr& params) :
     BehaviorModel(params),
     BaseIDM(params),
-    limit_steering_rate_(true),
-    constant_lane_corr_(nullptr) {
+    limit_steering_rate_(true) {
     crosstrack_error_gain_ =
         params->GetReal("BehaviorIDMLaneTracking::CrosstrackErrorGain",
                         "Tuning factor of stanley controller", 1.0);
@@ -49,10 +48,6 @@ class BehaviorIDMLaneTracking : public BaseIDM {
     limit_steering_rate_ = limit_steering;
   }
 
-  void SetConstantLaneCorridor(const LaneCorridorPtr& lc) {
-    constant_lane_corr_ = lc;
-  }
-
   void CheckAccelerationLimits(double acc_lon, double acc_lat) const;
 
   friend class BaseIDM;
@@ -60,7 +55,6 @@ class BehaviorIDMLaneTracking : public BaseIDM {
  private:
   double crosstrack_error_gain_;
   bool limit_steering_rate_;
-  LaneCorridorPtr constant_lane_corr_;
 };
 
 inline std::shared_ptr<BehaviorModel> BehaviorIDMLaneTracking::Clone() const {

--- a/bark/models/tests/behavior_idm_classic_test.cc
+++ b/bark/models/tests/behavior_idm_classic_test.cc
@@ -47,7 +47,7 @@ class DummyBehaviorIDM : public BehaviorIDMClassic {
     double acc;
     if (leading_vehicle.first) {
       double net_distance =
-          CalcNetDistance(observed_world, leading_vehicle.first);
+          CalcNetDistance(observed_world, leading_vehicle.first, observed_world.GetLaneCorridor());
       State other_vehicle_state = leading_vehicle.first->GetCurrentState();
       double vel_other = other_vehicle_state(StateDefinition::VEL_POSITION);
       acc = CalcIDMAcc(net_distance, vel_i, vel_other);
@@ -476,7 +476,7 @@ TEST(CalcNetDistance, behavior_idm_classic) {
       current_world_state->GetAgents().begin()->second->GetAgentId());
 
   BehaviorIDMClassic behavior(params);
-  double distance = behavior.CalcNetDistance(observed_world, agent2);
+  double distance = behavior.CalcNetDistance(observed_world, agent2, observed_world.GetLaneCorridor());
   double x_diff = init_state2(StateDefinition::X_POSITION) -
                  init_state1(StateDefinition::X_POSITION);
   double distance_expected =

--- a/bark/world/map/BUILD
+++ b/bark/world/map/BUILD
@@ -108,3 +108,14 @@ cc_library(
         "@boost//:graph",
     ]
 )
+
+cc_library(
+    name = "commons",
+    hdrs = [
+        "commons.hpp"
+    ],
+    deps = [
+        "//bark/world:world"
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/bark/world/map/commons.hpp
+++ b/bark/world/map/commons.hpp
@@ -60,17 +60,21 @@ inline LaneCorridorPtr ChooseLaneCorridorBasedOnVehicleState(
     }
 
     // if it is only in one lane corridor
-    if (other_lane_corr == nullptr)
-      return target_corr;
+    if (other_lane_corr == nullptr) {
+      // in this case we are entirely in one lane corridor
+      // here we want to only account for the preceeding vehicle
+      return observed_world.GetCurrentLaneCorridor();
+    }
 
-    // check if any point of the vehicle shape (front)
-    // is in the other lane corridor
+
+    // check if the front points of the ego vehicle are in the
+    // other lane corridor
     for (auto pt : vehicle_shape.obj_.outer()) {
       double pt_angle = atan2(
         bg::get<1>(ego_pose) - bg::get<1>(pt),
         bg::get<0>(ego_pose) - bg::get<0>(pt));
       double signed_angle_diff_lon = SignedAngleDiff(theta - M_PI_2, pt_angle);
-      // if a point is in front and inside the other lane corridor
+      // if a point in the front of the polygon is inside the other lane corridor
       // return that lane corridor
       if(Within(pt, other_lane_corr->GetMergedPolygon()) &&
          signed_angle_diff_lon > 0) {

--- a/bark/world/map/commons.hpp
+++ b/bark/world/map/commons.hpp
@@ -63,7 +63,7 @@ inline LaneCorridorPtr ChooseLaneCorridorBasedOnVehicleState(
     if (other_lane_corr == nullptr) {
       // in this case we are entirely in one lane corridor
       // here we want to only account for the preceeding vehicle
-      return observed_world.GetCurrentLaneCorridor();
+      return observed_world.GetLaneCorridor();
     }
 
 

--- a/bark/world/map/commons.hpp
+++ b/bark/world/map/commons.hpp
@@ -29,6 +29,16 @@ namespace bg = boost::geometry;
 using models::dynamic::StateDefinition;
 using bark::geometry::SignedAngleDiff;
 
+/**
+ * @brief  Function that selects LaneCorridors
+ * @note   If an agent is in two LaneCorridors with its shape
+ *         the other one it selected if the front points of the
+ *         agent are within the other lane corridor.
+ *         This models an entering of the other lane corridor.
+ * @param  observed_world: ObservedWorld of agent
+ * @param  target_corr: fallback corridor in case calculation fails
+ * @retval LaneCorridorPtr: the computed lane corridor
+ */
 inline LaneCorridorPtr ChooseLaneCorridorBasedOnVehicleState(
   const ObservedWorld& observed_world, const LaneCorridorPtr& target_corr) {
     // ego info

--- a/bark/world/map/commons.hpp
+++ b/bark/world/map/commons.hpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2020 fortiss GmbH
+//
+// Authors: Julian Bernhard, Klemens Esterle, Patrick Hart and
+// Tobias Kessler
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+#ifndef BARK_WORLD_MAP_COMMONS_HPP_
+#define BARK_WORLD_MAP_COMMONS_HPP_
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "bark/geometry/geometry.hpp"
+#include "bark/world/world.hpp"
+
+namespace bark {
+namespace world {
+namespace map {
+
+using bark::geometry::Point2d;
+using bark::geometry::Polygon;
+using bark::geometry::Within;
+using bark::world::ObservedWorld;
+namespace bg = boost::geometry;
+using models::dynamic::StateDefinition;
+using bark::geometry::SignedAngleDiff;
+
+inline LaneCorridorPtr ChooseLaneCorridorBasedOnVehicleState(
+  const ObservedWorld& observed_world, const LaneCorridorPtr& target_corr) {
+    // ego info
+    auto ego_agent = observed_world.GetEgoAgent();
+    auto ego_pose = ego_agent->GetCurrentPosition();
+    auto ego_state = ego_agent->GetCurrentState();
+    auto theta = ego_state(StateDefinition::THETA_POSITION); 
+    Polygon vehicle_shape = ego_agent->GetPolygonFromState(ego_state);
+
+    // road and lane corridor info
+    auto road_corridor = ego_agent->GetRoadCorridor();
+
+    // 1. check if vehicle shape intersects with an other lane corridor
+    LaneCorridorPtr other_lane_corr;
+    for (auto& lc : road_corridor->GetUniqueLaneCorridors()) {
+      if (Collide(vehicle_shape, lc->GetMergedPolygon()) &&
+          lc != target_corr)
+        other_lane_corr = lc;
+    }
+
+    // if it is only in one lane corridor
+    if (other_lane_corr == nullptr)
+      return target_corr;
+
+    // check if any point of the vehicle shape (front)
+    // is in the other lane corridor
+    for (auto pt : vehicle_shape.obj_.outer()) {
+      double pt_angle = atan2(
+        bg::get<1>(ego_pose) - bg::get<1>(pt),
+        bg::get<0>(ego_pose) - bg::get<0>(pt));
+      double signed_angle_diff_lon = SignedAngleDiff(theta - M_PI_2, pt_angle);
+      // if a point is in front and inside the other lane corridor
+      // return that lane corridor
+      if(Within(pt, other_lane_corr->GetMergedPolygon()) &&
+         signed_angle_diff_lon > 0) {
+        return other_lane_corr;
+      }
+    }
+
+    // 3. fallback return and log message
+    VLOG(4) << "Could not calculate the lane corridor." << std::endl;
+    return target_corr;
+}
+
+}  // namespace map
+}  // namespace world
+}  // namespace bark
+
+#endif  // BARK_WORLD_MAP_COMMONS_HPP_

--- a/bark/world/map/lane_corridor.hpp
+++ b/bark/world/map/lane_corridor.hpp
@@ -29,6 +29,7 @@ using bark::geometry::Point2d;
 using bark::geometry::Polygon;
 using bark::geometry::Within;
 using bark::world::opendrive::XodrRoadId;
+namespace bg = boost::geometry;
 
 struct LaneCorridor {
   using LaneCorridorPtr = std::shared_ptr<LaneCorridor>;
@@ -103,6 +104,7 @@ inline std::ostream& operator<<(std::ostream& os, LaneCorridor& lc) {
     << " width(end): " << lc.GetLaneWidth(center_last_pt) << ")";
   return os;
 }
+
 
 }  // namespace map
 }  // namespace world


### PR DESCRIPTION
* if a static lane corridor is set, the LaneCorridor is now chosen using `ChooseLaneCorridorBasedOnVehicleState`
* ChooseLaneCorridorBasedOnVehicleState computes the lane corridor based on intersections and checks if any of the agent's polygon points in the front are in the other LaneCorridor

Observation: harsh braking does not occur directly at the beginning of the episode.