### PR TITLE
ObserverModel for the ObservedWorld Generation

### DIFF
--- a/bark/models/BUILD
+++ b/bark/models/BUILD
@@ -2,6 +2,7 @@ cc_library(
     name="include",
     deps= [
         "//bark/models/behavior:include",
+        "//bark/models/observer:include",
         "//bark/models/dynamic:include",
         "//bark/models/execution:include",
     ],

--- a/bark/models/observer/BUILD
+++ b/bark/models/observer/BUILD
@@ -1,0 +1,36 @@
+cc_library(
+    name = "observer_model",
+    hdrs = [
+        "observer_model.hpp",
+    ],
+    deps = [
+        "//bark/commons:commons",
+        "//bark/world:world",
+        "@com_github_eigen_eigen//:eigen",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "observer_model_none",
+    hdrs = [
+        "observer_model_none.hpp",
+    ],
+    deps = [
+        "//bark/commons:commons",
+        "//bark/world:world",
+        "//bark/models/observer:observer",
+        "@com_github_eigen_eigen//:eigen",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name="include",
+    hdrs= ["observer_model.hpp"],
+    deps = [
+        # "//bark/models/observer/one_to_one:include",
+        "@com_github_eigen_eigen//:eigen",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/bark/models/observer/BUILD
+++ b/bark/models/observer/BUILD
@@ -19,7 +19,7 @@ cc_library(
     deps = [
         "//bark/commons:commons",
         "//bark/world:world",
-        "//bark/models/observer:observer",
+        "//bark/models/observer:observer_model",
         "@com_github_eigen_eigen//:eigen",
     ],
     visibility = ["//visibility:public"],
@@ -29,7 +29,8 @@ cc_library(
     name="include",
     hdrs= ["observer_model.hpp"],
     deps = [
-        # "//bark/models/observer/one_to_one:include",
+        "//bark/models/observer:observer_model",
+        "//bark/models/observer:observer_model_none",
         "@com_github_eigen_eigen//:eigen",
     ],
     visibility = ["//visibility:public"],

--- a/bark/models/observer/BUILD
+++ b/bark/models/observer/BUILD
@@ -5,7 +5,6 @@ cc_library(
     ],
     deps = [
         "//bark/commons:commons",
-        "//bark/world:world",
         "@com_github_eigen_eigen//:eigen",
     ],
     visibility = ["//visibility:public"],
@@ -18,7 +17,6 @@ cc_library(
     ],
     deps = [
         "//bark/commons:commons",
-        "//bark/world:world",
         "//bark/models/observer:observer_model",
         "@com_github_eigen_eigen//:eigen",
     ],

--- a/bark/models/observer/observer_model.hpp
+++ b/bark/models/observer/observer_model.hpp
@@ -16,12 +16,23 @@
 #include "bark/commons/base_type.hpp"
 
 namespace bark {
+
+// forward declarations
+namespace world {
+namespace objects {
+typedef unsigned int AgentId;
+}  // namespace objects
+class ObservedWorld;
+class World;
+typedef std::shared_ptr<World> WorldPtr;
+}  // namespace world
+
 namespace models {
 namespace observer {
-using bark::world::World;
-using bark::world::WorldPtr;
-using bark::world::AgentId;
-using bark::world::ObservedWorld;
+using world::objects::AgentId;
+using world::World;
+using world::ObservedWorld;
+using world::WorldPtr;
 
 /**
  * @brief  Observer creating an ObservedWorld given a World
@@ -40,7 +51,7 @@ class ObserverModel : public commons::BaseType {
 
   /**
    * @brief Function for generating an ObservedWorld
-   * @param  world: BARK world
+   * @param  world: BARK-world
    *         agent_id: id of the agent
    * @retval  Returns an ObservedWorld
    */

--- a/bark/models/observer/observer_model.hpp
+++ b/bark/models/observer/observer_model.hpp
@@ -6,10 +6,9 @@
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
-#ifndef BARK_MODELS_EXECUTION_OBSERVER_MODEL_HPP_
-#define BARK_MODELS_EXECUTION_OBSERVER_MODEL_HPP_
+#ifndef BARK_MODELS_OBSERVER_OBSERVER_MODEL_HPP_
+#define BARK_MODELS_OBSERVER_OBSERVER_MODEL_HPP_
 
-#include <Eigen/Core>
 #include <memory>
 #include "bark/commons/base_type.hpp"
 
@@ -69,4 +68,4 @@ typedef std::shared_ptr<ObserverModel> ObserverModelPtr;
 }  // namespace models
 }  // namespace bark
 
-#endif  // BARK_MODELS_EXECUTION_OBSERVER_MODEL_HPP_
+#endif  // BARK_MODELS_OBSERVER_OBSERVER_MODEL_HPP_

--- a/bark/models/observer/observer_model.hpp
+++ b/bark/models/observer/observer_model.hpp
@@ -55,11 +55,6 @@ class ObserverModel : public commons::BaseType {
   virtual ObservedWorld Observe(
     const WorldPtr& world, const AgentId& agent_id) = 0;
 
-  /**
-   * @brief  Function specifying how the world shall be cloned
-   */
-  virtual std::shared_ptr<ObserverModel> Clone() const = 0;
-
 };
 
 typedef std::shared_ptr<ObserverModel> ObserverModelPtr;

--- a/bark/models/observer/observer_model.hpp
+++ b/bark/models/observer/observer_model.hpp
@@ -11,8 +11,6 @@
 
 #include <Eigen/Core>
 #include <memory>
-#include "bark/world/world.hpp"
-#include "bark/world/observed_world.hpp"
 #include "bark/commons/base_type.hpp"
 
 namespace bark {

--- a/bark/models/observer/observer_model.hpp
+++ b/bark/models/observer/observer_model.hpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2020 fortiss GmbH
+//
+// Authors: Julian Bernhard, Klemens Esterle, Patrick Hart and
+// Tobias Kessler
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#ifndef BARK_MODELS_EXECUTION_OBSERVER_MODEL_HPP_
+#define BARK_MODELS_EXECUTION_OBSERVER_MODEL_HPP_
+
+#include <Eigen/Core>
+#include <memory>
+#include "bark/world/world.hpp"
+#include "bark/world/observed_world.hpp"
+#include "bark/commons/base_type.hpp"
+
+namespace bark {
+namespace models {
+namespace observer {
+using bark::world::World;
+using bark::world::ObservedWorld;
+
+/**
+ * @brief  Observer creating an ObservedWorld given a World
+ * @note   
+ * @retval None
+ */
+class ObserverModel : public commons::BaseType {
+ public:
+  explicit ObserverModel(bark::commons::ParamsPtr params)
+    : BaseType(params) {}
+
+  ObserverModel(const ObserverModel& execution_model)
+    : BaseType(execution_model.GetParams()) {}
+
+  virtual ~ObserverModel() {}
+
+  /**
+   * @brief Function for generating an ObservedWorld
+   * @param  world: BARK world
+   * @retval  Returns an ObservedWorld
+   */
+  virtual ObservedWorld Observe(const World& world) = 0;
+
+  /**
+   * @brief  Function specifying how the world shall be cloned
+   */
+  virtual std::shared_ptr<ObserverModel> Clone() const = 0;
+
+};
+
+typedef std::shared_ptr<ObserverModel> ObserverModelPtr;
+
+}  // namespace observer
+}  // namespace models
+}  // namespace bark
+
+#endif  // BARK_MODELS_EXECUTION_OBSERVER_MODEL_HPP_

--- a/bark/models/observer/observer_model.hpp
+++ b/bark/models/observer/observer_model.hpp
@@ -19,6 +19,8 @@ namespace bark {
 namespace models {
 namespace observer {
 using bark::world::World;
+using bark::world::WorldPtr;
+using bark::world::AgentId;
 using bark::world::ObservedWorld;
 
 /**
@@ -31,17 +33,19 @@ class ObserverModel : public commons::BaseType {
   explicit ObserverModel(bark::commons::ParamsPtr params)
     : BaseType(params) {}
 
-  ObserverModel(const ObserverModel& execution_model)
-    : BaseType(execution_model.GetParams()) {}
+  ObserverModel(const ObserverModel& observer_model)
+    : BaseType(observer_model.GetParams()) {}
 
   virtual ~ObserverModel() {}
 
   /**
    * @brief Function for generating an ObservedWorld
    * @param  world: BARK world
+   *         agent_id: id of the agent
    * @retval  Returns an ObservedWorld
    */
-  virtual ObservedWorld Observe(const World& world) = 0;
+  virtual ObservedWorld Observe(
+    const WorldPtr& world, const AgentId& agent_id) = 0;
 
   /**
    * @brief  Function specifying how the world shall be cloned

--- a/bark/models/observer/observer_model_none.hpp
+++ b/bark/models/observer/observer_model_none.hpp
@@ -48,18 +48,7 @@ class ObserverModelNone : public ObserverModel {
     return observed_world;
   }
 
-  /**
-   * @brief  Function specifying how the world shall be cloned
-   */
-  virtual std::shared_ptr<ObserverModel> Clone() const;
-
 };
-
-inline std::shared_ptr<ObserverModel> ObserverModelNone::Clone() const {
-  std::shared_ptr<ObserverModelNone> model_ptr =
-      std::make_shared<ObserverModelNone>(*this);
-  return model_ptr;
-}
 
 typedef std::shared_ptr<ObserverModelNone> ObserverModelNonePtr;
 

--- a/bark/models/observer/observer_model_none.hpp
+++ b/bark/models/observer/observer_model_none.hpp
@@ -6,10 +6,9 @@
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
-#ifndef BARK_MODELS_EXECUTION_OBSERVER_MODEL_NONE_HPP_
-#define BARK_MODELS_EXECUTION_OBSERVER_MODEL_NONE_HPP_
+#ifndef BARK_MODELS_OBSERVER_OBSERVER_MODEL_NONE_HPP_
+#define BARK_MODELS_OBSERVER_OBSERVER_MODEL_NONE_HPP_
 
-#include <Eigen/Core>
 #include <memory>
 #include "bark/world/world.hpp"
 #include "bark/world/observed_world.hpp"
@@ -68,4 +67,4 @@ typedef std::shared_ptr<ObserverModelNone> ObserverModelNonePtr;
 }  // namespace models
 }  // namespace bark
 
-#endif  // BARK_MODELS_EXECUTION_OBSERVER_MODEL_NONE_HPP_
+#endif  // BARK_MODELS_OBSERVER_OBSERVER_MODEL_NONE_HPP_

--- a/bark/models/observer/observer_model_none.hpp
+++ b/bark/models/observer/observer_model_none.hpp
@@ -20,7 +20,7 @@ namespace models {
 namespace observer {
 using bark::world::World;
 using bark::world::WorldPtr;
-using bark::world::AgentId;
+using bark::world::objects::AgentId;
 using bark::world::ObservedWorld;
 
 /**

--- a/bark/models/observer/observer_model_none.hpp
+++ b/bark/models/observer/observer_model_none.hpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2020 fortiss GmbH
+//
+// Authors: Julian Bernhard, Klemens Esterle, Patrick Hart and
+// Tobias Kessler
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#ifndef BARK_MODELS_EXECUTION_OBSERVER_MODEL_NONE_HPP_
+#define BARK_MODELS_EXECUTION_OBSERVER_MODEL_NONE_HPP_
+
+#include <Eigen/Core>
+#include <memory>
+#include "bark/world/world.hpp"
+#include "bark/world/observed_world.hpp"
+#include "bark/models/observer/observed_model.hpp"
+#include "bark/commons/base_type.hpp"
+
+namespace bark {
+namespace models {
+namespace observer {
+using bark::world::World;
+using bark::world::ObservedWorld;
+
+/**
+ * @brief  Observer creating an ObservedWorld given a World
+ * @note   
+ * @retval None
+ */
+class ObserverModelNone : public ObserverModel {
+ public:
+  explicit ObserverModelNone(bark::commons::ParamsPtr params)
+    : BaseType(params) {}
+
+  ObserverModelNone(const ObserverModelNone& execution_model)
+    : BaseType(execution_model.GetParams()) {}
+
+  virtual ~ObserverModelNone() {}
+
+  /**
+   * @brief Clones the world and generated an ObservedWrodl
+   * @retval  Returns an ObservedWorld
+   */
+  virtual ObservedWorld Observe(const World& world) override {
+
+  }
+
+  /**
+   * @brief  Function specifying how the world shall be cloned
+   */
+  virtual std::shared_ptr<ObserverModel> Clone() override;
+
+};
+
+inline std::shared_ptr<ObserverModel> ObserverModelNone::Clone() const {
+  std::shared_ptr<ObserverModelNone> model_ptr =
+      std::make_shared<ObserverModelNone>(*this);
+  return model_ptr;
+}
+
+typedef std::shared_ptr<ObserverModelNone> ObserverModelNonePtr;
+
+}  // namespace observer
+}  // namespace models
+}  // namespace bark
+
+#endif  // BARK_MODELS_EXECUTION_OBSERVER_MODEL_NONE_HPP_

--- a/bark/models/observer/observer_model_none.hpp
+++ b/bark/models/observer/observer_model_none.hpp
@@ -13,13 +13,14 @@
 #include <memory>
 #include "bark/world/world.hpp"
 #include "bark/world/observed_world.hpp"
-#include "bark/models/observer/observed_model.hpp"
 #include "bark/commons/base_type.hpp"
 
 namespace bark {
 namespace models {
 namespace observer {
 using bark::world::World;
+using bark::world::WorldPtr;
+using bark::world::AgentId;
 using bark::world::ObservedWorld;
 
 /**
@@ -30,10 +31,10 @@ using bark::world::ObservedWorld;
 class ObserverModelNone : public ObserverModel {
  public:
   explicit ObserverModelNone(bark::commons::ParamsPtr params)
-    : BaseType(params) {}
+    : ObserverModel(params) {}
 
-  ObserverModelNone(const ObserverModelNone& execution_model)
-    : BaseType(execution_model.GetParams()) {}
+  ObserverModelNone(const ObserverModelNone& observer_model)
+    : ObserverModel(observer_model.GetParams()) {}
 
   virtual ~ObserverModelNone() {}
 
@@ -41,14 +42,17 @@ class ObserverModelNone : public ObserverModel {
    * @brief Clones the world and generated an ObservedWrodl
    * @retval  Returns an ObservedWorld
    */
-  virtual ObservedWorld Observe(const World& world) override {
-
+  virtual ObservedWorld Observe(
+    const WorldPtr& world, const AgentId& agent_id) {
+    // NOTE: this creates a standard observed world
+    ObservedWorld observed_world(world, agent_id);
+    return observed_world;
   }
 
   /**
    * @brief  Function specifying how the world shall be cloned
    */
-  virtual std::shared_ptr<ObserverModel> Clone() override;
+  virtual std::shared_ptr<ObserverModel> Clone() const;
 
 };
 

--- a/bark/models/tests/BUILD
+++ b/bark/models/tests/BUILD
@@ -39,9 +39,10 @@ cc_test(
     copts = ["-Iexternal/gtest/include"],
     deps = [
         "//bark/geometry",
+        "//bark/world:world",
+        "//bark/world/goal_definition:goal_definition",
         "//bark/models/observer:observer_model",
         "//bark/models/observer:observer_model_none",
-        "//bark/world/goal_definition:goal_definition",
         "@gtest//:gtest_main",
     ],
 )

--- a/bark/models/tests/BUILD
+++ b/bark/models/tests/BUILD
@@ -43,6 +43,7 @@ cc_test(
         "//bark/world/goal_definition:goal_definition",
         "//bark/models/observer:observer_model",
         "//bark/models/observer:observer_model_none",
+        "//bark/world/tests:make_test_world",
         "@gtest//:gtest_main",
     ],
 )

--- a/bark/models/tests/BUILD
+++ b/bark/models/tests/BUILD
@@ -40,6 +40,8 @@ cc_test(
     deps = [
         "//bark/geometry",
         "//bark/models/observer:observer_model",
+        "//bark/models/observer:observer_model_none",
+        "//bark/world/goal_definition:goal_definition",
         "@gtest//:gtest_main",
     ],
 )

--- a/bark/models/tests/BUILD
+++ b/bark/models/tests/BUILD
@@ -112,6 +112,17 @@ py_test(
           "//bark/runtime/scenario/scenario_generation:scenario_generation"],
 )
 
+py_test(
+  name = "py_observer_model_test",
+  srcs = ["py_observer_model_test.py"],
+  data = ['//bark:generate_core',
+          '//bark/runtime/tests:xodr_data'],
+
+  deps = ["//bark/runtime/commons:commons",
+          "//bark/runtime:runtime",
+          "//bark/runtime/scenario/scenario_generation:scenario_generation"],
+)
+
 cc_test(
     name = "behavior_static_trajectory_test",
     srcs = [

--- a/bark/models/tests/BUILD
+++ b/bark/models/tests/BUILD
@@ -32,6 +32,19 @@ cc_test(
 )
 
 cc_test(
+    name = "observer_model_test",
+    srcs = [
+        "observer_model_test.cc",
+    ],
+    copts = ["-Iexternal/gtest/include"],
+    deps = [
+        "//bark/geometry",
+        "//bark/models/observer:observer_model",
+        "@gtest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "behavior_motion_primitive_test",
     srcs = [
         "behavior_motion_primitive_test.cc",

--- a/bark/models/tests/observer_model_test.cc
+++ b/bark/models/tests/observer_model_test.cc
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 fortiss GmbH
+//
+// Authors: Julian Bernhard, Klemens Esterle, Patrick Hart and
+// Tobias Kessler
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "bark/models/observer/observer_model.hpp"
+#include "gtest/gtest.h"
+#include "bark/commons/params/setter_params.hpp"
+
+using bark::commons::SetterParams;
+
+TEST(observer_model, IF_tests) {
+  auto params = std::make_shared<SetterParams>();
+
+
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/bark/models/tests/observer_model_test.cc
+++ b/bark/models/tests/observer_model_test.cc
@@ -8,36 +8,38 @@
 #include "gtest/gtest.h"
 #include "bark/models/observer/observer_model.hpp"
 #include "bark/models/observer/observer_model_none.hpp"
-// #include "bark/world/tests/make_test_world.hpp"
+#include "bark/world/tests/make_test_world.hpp"
 #include "bark/commons/params/setter_params.hpp"
 
 using bark::commons::SetterParams;
-
-TEST(observer_model, IF_tests) {
-  auto params = std::make_shared<SetterParams>();
-
-}
+using bark::geometry::Polygon;
+using bark::geometry::Point2d;
+using bark::geometry::standard_shapes::GenerateGoalRectangle;
+using bark::world::goal_definition::GoalDefinitionPolygon;
+using bark::world::objects::AgentId;
+using bark::world::tests::make_test_world;
+using namespace bark::world;
 
 TEST(observer_model_none, base_test) {
   using bark::models::observer::ObserverModelNone;
   auto params = std::make_shared<SetterParams>();
   ObserverModelNone observer_none(params);
 
-  // TODO: integrate test
-  // Polygon polygon = GenerateGoalRectangle(6,3);
-  // std::shared_ptr<Polygon> goal_polygon(
-  //     std::dynamic_pointer_cast<Polygon>(polygon.Translate(
-  //         Point2d(50, -2))));  // < move the goal polygon into the driving
-  //                              // corridor in front of the ego vehicle
-  // auto goal_definition_ptr =
-  //     std::make_shared<GoalDefinitionPolygon>(*goal_polygon);
-  // double ego_velocity = 5.0, rel_distance = 2.0, velocity_difference = 2.0;
-  // // TODO: pass goal polygon to make_world_test
-  // WorldPtr world = make_test_world(0, rel_distance, ego_velocity,
-  //                                  velocity_difference, goal_definition_ptr);
+  Polygon polygon = GenerateGoalRectangle(6,3);
+  std::shared_ptr<Polygon> goal_polygon(
+    std::dynamic_pointer_cast<Polygon>(polygon.Translate(
+      Point2d(50, -2))));  // < move the goal polygon into the driving
+                            // corridor in front of the ego vehicle
+  auto goal_definition_ptr =
+      std::make_shared<GoalDefinitionPolygon>(*goal_polygon);
+  double ego_velocity = 5.0, rel_distance = 2.0, velocity_difference = 2.0;
+  WorldPtr world = make_test_world(0, rel_distance, ego_velocity,
+                                   velocity_difference, goal_definition_ptr);
 
-  // TODO: call observer
-  // observer_none.Observer();
+  ObservedWorld observed_world = observer_none.Observe(world, AgentId(1));
+
+  // NOTE: assert ObservedWorld is generated for the correct AgentId
+  EXPECT_EQ(observed_world.GetEgoAgentId(), AgentId(1));
 }
 
 int main(int argc, char** argv) {

--- a/bark/models/tests/observer_model_test.cc
+++ b/bark/models/tests/observer_model_test.cc
@@ -23,6 +23,7 @@ TEST(observer_model_none, base_test) {
   auto params = std::make_shared<SetterParams>();
   ObserverModelNone observer_none(params);
 
+  // TODO: integrate test
   // Polygon polygon = GenerateGoalRectangle(6,3);
   // std::shared_ptr<Polygon> goal_polygon(
   //     std::dynamic_pointer_cast<Polygon>(polygon.Translate(
@@ -35,7 +36,7 @@ TEST(observer_model_none, base_test) {
   // WorldPtr world = make_test_world(0, rel_distance, ego_velocity,
   //                                  velocity_difference, goal_definition_ptr);
 
-
+  // TODO: call observer
   // observer_none.Observer();
 }
 

--- a/bark/models/tests/observer_model_test.cc
+++ b/bark/models/tests/observer_model_test.cc
@@ -5,9 +5,10 @@
 //
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
-
-#include "bark/models/observer/observer_model.hpp"
 #include "gtest/gtest.h"
+#include "bark/models/observer/observer_model.hpp"
+#include "bark/models/observer/observer_model_none.hpp"
+// #include "bark/world/tests/make_test_world.hpp"
 #include "bark/commons/params/setter_params.hpp"
 
 using bark::commons::SetterParams;
@@ -15,7 +16,27 @@ using bark::commons::SetterParams;
 TEST(observer_model, IF_tests) {
   auto params = std::make_shared<SetterParams>();
 
+}
 
+TEST(observer_model_none, base_test) {
+  using bark::models::observer::ObserverModelNone;
+  auto params = std::make_shared<SetterParams>();
+  ObserverModelNone observer_none(params);
+
+  // Polygon polygon = GenerateGoalRectangle(6,3);
+  // std::shared_ptr<Polygon> goal_polygon(
+  //     std::dynamic_pointer_cast<Polygon>(polygon.Translate(
+  //         Point2d(50, -2))));  // < move the goal polygon into the driving
+  //                              // corridor in front of the ego vehicle
+  // auto goal_definition_ptr =
+  //     std::make_shared<GoalDefinitionPolygon>(*goal_polygon);
+  // double ego_velocity = 5.0, rel_distance = 2.0, velocity_difference = 2.0;
+  // // TODO: pass goal polygon to make_world_test
+  // WorldPtr world = make_test_world(0, rel_distance, ego_velocity,
+  //                                  velocity_difference, goal_definition_ptr);
+
+
+  // observer_none.Observer();
 }
 
 int main(int argc, char** argv) {

--- a/bark/models/tests/py_observer_model_test.py
+++ b/bark/models/tests/py_observer_model_test.py
@@ -38,8 +38,6 @@ class PythonObserverModel(ObserverModel):
     observed_world = ObservedWorld(world, agent_id)
     return observed_world
 
-  def Clone(self):
-    return self
 
 def GetParamServerAndWorld():
   param_server = ParameterServer(

--- a/bark/models/tests/py_observer_model_test.py
+++ b/bark/models/tests/py_observer_model_test.py
@@ -17,13 +17,13 @@ from bark.runtime.scenario.scenario_generation.scenario_generation \
 
 from bark.core.world.goal_definition import GoalDefinition, GoalDefinitionPolygon
 from bark.core.geometry import *
-from bark.core.world import World
+from bark.core.world import World, ObservedWorld
 from bark.runtime.commons.parameters import ParameterServer
 from bark.runtime.runtime import Runtime
 from bark.runtime.viewer.matplotlib_viewer import MPViewer
 from bark.core.models.behavior import BehaviorModel, BehaviorDynamicModel
 from bark.core.models.dynamic import SingleTrackModel
-from bark.core.models.observer import *
+from bark.core.models.observer import ObserverModel, ObserverModelNone
 
 
 # NOTE: this is testing the PyObserverModel wrapping
@@ -31,12 +31,11 @@ class PythonObserverModel(ObserverModel):
   def __init__(self,
                params = None):
     ObserverModel.__init__(self, params)
-    self._dynamic_model = dynamic_model
     self._params = params
 
   def Observe(self, world, agent_id):
-    # NOTE: returns an vector as this could return mult. observed worlds
-    observed_world = world.Observe([agent_id])[0]
+    # NOTE: returns a vector as this could return mult. observed worlds
+    observed_world = ObservedWorld(world, agent_id)
     return observed_world
 
   def Clone(self):
@@ -66,7 +65,7 @@ def GetParamServerAndWorld():
 
 class PyObserverModelTests(unittest.TestCase):
   def test_observer_model_none(self):
-    param_server, world = GetParamServerAndWorld()
+    world, param_server = GetParamServerAndWorld()
     # NOTE: create and assign ObserverModelNone
     observer_model = ObserverModelNone(param_server)
     world.observer_model = observer_model
@@ -74,8 +73,8 @@ class PyObserverModelTests(unittest.TestCase):
     assert(world.observer_model == observer_model)
     
   def test_py_observer_model_none(self):
-    param_server, world = GetParamServerAndWorld()
-    # NOTE: create and assign ObserverModelNone
+    world, param_server = GetParamServerAndWorld()
+    # NOTE: create and assign PythonObserverModel
     observer_model = PythonObserverModel(param_server)
     world.observer_model = observer_model
     world.Step(0.2)

--- a/bark/models/tests/py_observer_model_test.py
+++ b/bark/models/tests/py_observer_model_test.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2020 fortiss GmbH
+#
+# Authors: Julian Bernhard, Klemens Esterle, Patrick Hart and
+# Tobias Kessler
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+
+import unittest
+import os
+import numpy as np
+from bark.runtime.scenario.scenario_generation.deterministic \
+  import DeterministicScenarioGeneration
+from bark.runtime.scenario.scenario_generation.scenario_generation \
+  import ScenarioGeneration
+
+from bark.core.world.goal_definition import GoalDefinition, GoalDefinitionPolygon
+from bark.core.geometry import *
+from bark.core.world import World
+from bark.runtime.commons.parameters import ParameterServer
+from bark.runtime.runtime import Runtime
+from bark.runtime.viewer.matplotlib_viewer import MPViewer
+from bark.core.models.behavior import BehaviorModel, BehaviorDynamicModel
+from bark.core.models.dynamic import SingleTrackModel
+from bark.core.models.observer import *
+
+
+# NOTE: this is testing the PyObserverModel wrapping
+class PythonObserverModel(ObserverModel):
+  def __init__(self,
+               params = None):
+    ObserverModel.__init__(self, params)
+    self._dynamic_model = dynamic_model
+    self._params = params
+
+  def Observe(self, world, agent_id):
+    # NOTE: returns an vector as this could return mult. observed worlds
+    observed_world = world.Observe([agent_id])[0]
+    return observed_world
+
+  def Clone(self):
+    return self
+
+def GetParamServerAndWorld():
+  param_server = ParameterServer(
+    filename=os.path.join(
+      os.path.dirname(__file__),
+      "../../runtime/tests/data/deterministic_scenario.json"))
+      
+  mapfile = os.path.join(
+    os.path.dirname(__file__),
+    "../../runtime/tests/data/city_highway_straight.xodr")
+  
+  param_server["Scenario"]["Generation"]["DeterministicScenarioGeneration"]["MapFilename"] = mapfile
+  scenario_generation = DeterministicScenarioGeneration(num_scenarios=3,
+                                                        random_seed=0,
+                                                        params=param_server)
+  viewer = MPViewer(params=param_server,
+                    follow_agent_id=False,
+                    use_world_bounds=True)
+  scenario, idx = scenario_generation.get_next_scenario()
+  world = scenario.GetWorldState()
+  return world, param_server
+
+
+class PyObserverModelTests(unittest.TestCase):
+  def test_observer_model_none(self):
+    param_server, world = GetParamServerAndWorld()
+    # NOTE: create and assign ObserverModelNone
+    observer_model = ObserverModelNone(param_server)
+    world.observer_model = observer_model
+    world.Step(0.2)
+    assert(world.observer_model == observer_model)
+    
+  def test_py_observer_model_none(self):
+    param_server, world = GetParamServerAndWorld()
+    # NOTE: create and assign ObserverModelNone
+    observer_model = PythonObserverModel(param_server)
+    world.observer_model = observer_model
+    world.Step(0.2)
+    assert(world.observer_model == observer_model)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/bark/python_wrapper/BUILD
+++ b/bark/python_wrapper/BUILD
@@ -40,7 +40,7 @@ cc_binary(
     "//bark/models/behavior/idm/stochastic:stochastic",
     "//bark/models/behavior/behavior_safety:behavior_safety",
     "//bark/models/behavior/behavior_rss:behavior_rss",
-    #"//bark/models/execution/mpc:mpc",
+    "//bark/models/observer:observer_model",
     "//bark/runtime/viewer:viewer",
     "//bark/world:world",
     "//bark/runtime:cc_runtime",

--- a/bark/python_wrapper/models/models.cpp
+++ b/bark/python_wrapper/models/models.cpp
@@ -10,6 +10,7 @@
 #include "bark/python_wrapper/models/behavior.hpp"
 #include "bark/python_wrapper/models/dynamic.hpp"
 #include "bark/python_wrapper/models/execution.hpp"
+#include "bark/python_wrapper/models/observer.hpp"
 
 void python_models(py::module m) {
   python_behavior(m.def_submodule("behavior", "Behavior wrapping"));
@@ -17,4 +18,6 @@ void python_models(py::module m) {
       "execution", "submodule containing all wrapped execution models"));
   python_dynamic(m.def_submodule(
       "dynamic", "submodule containing all wrapped dynamic models"));
+  python_observer(m.def_submodule(
+      "observer", "submodule containing observers"));
 }

--- a/bark/python_wrapper/models/observer.cpp
+++ b/bark/python_wrapper/models/observer.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2020 fortiss GmbH
+//
+// Authors: Julian Bernhard, Klemens Esterle, Patrick Hart and
+// Tobias Kessler
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "Observer.hpp"
+#include <string>
+
+namespace py = pybind11;
+using namespace bark::commons;
+using std::shared_ptr;
+
+void python_observer(py::module m) {
+  py::class_<ObserverModel, PyObserverModel, ObserverModelPtr>(
+      m, "ObserverModel")
+      .def(py::init<const ParamsPtr&>())
+      .def("Observe", &ObserverModel::Observe);
+}

--- a/bark/python_wrapper/models/observer.cpp
+++ b/bark/python_wrapper/models/observer.cpp
@@ -15,7 +15,25 @@ using std::shared_ptr;
 
 void python_observer(py::module m) {
   py::class_<ObserverModel, PyObserverModel, ObserverModelPtr>(
-      m, "ObserverModel")
-      .def(py::init<const ParamsPtr&>())
-      .def("Observe", &ObserverModel::Observe);
+    m, "ObserverModel")
+    .def(py::init<const ParamsPtr&>())
+    .def("Observe", &ObserverModel::Observe);
+
+  py::class_<ObserverModelNone, ObserverModel,
+             shared_ptr<ObserverModelNone>>(m, "ObserverNone")
+    .def(py::init<const ParamsPtr&>())
+    .def("__repr__", [](const ObserverModelNone& m) {
+          return "bark.models.observer.ObserverNone";
+    })
+    .def(py::pickle([](const ObserverModelNone& b) {
+        return py::make_tuple(ParamsToPython(b.GetParams()));
+      },
+      [](py::tuple t) {
+        if (t.size() != 1)
+          throw std::runtime_error("Invalid observer model state!");
+        /* Create a new C++ instance */
+        return new ObserverModelNone(
+            PythonToParams(t[0].cast<py::tuple>()));
+    }));
+
 }

--- a/bark/python_wrapper/models/observer.cpp
+++ b/bark/python_wrapper/models/observer.cpp
@@ -16,12 +16,12 @@ using std::shared_ptr;
 void python_observer(py::module m) {
   py::class_<ObserverModel, PyObserverModel, ObserverModelPtr>(
     m, "ObserverModel")
-    .def(py::init<const ParamsPtr&>())
+    .def(py::init<const bark::commons::ParamsPtr&>())
     .def("Observe", &ObserverModel::Observe);
 
   py::class_<ObserverModelNone, ObserverModel,
-             shared_ptr<ObserverModelNone>>(m, "ObserverNone")
-    .def(py::init<const ParamsPtr&>())
+             shared_ptr<ObserverModelNone>>(m, "ObserverModelNone")
+    .def(py::init<const bark::commons::ParamsPtr&>())
     .def("__repr__", [](const ObserverModelNone& m) {
           return "bark.models.observer.ObserverNone";
     })

--- a/bark/python_wrapper/models/observer.cpp
+++ b/bark/python_wrapper/models/observer.cpp
@@ -6,7 +6,7 @@
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
-#include "Observer.hpp"
+#include "observer.hpp"
 #include <string>
 
 namespace py = pybind11;

--- a/bark/python_wrapper/models/observer.hpp
+++ b/bark/python_wrapper/models/observer.hpp
@@ -13,13 +13,17 @@
 
 namespace py = pybind11;
 using namespace bark::models::observer;
+using bark::world::AgentId;
+using bark::world::dWorldPtr;
 
 class PyObserverModel : public ObserverModel {
  public:
   using ObserverModel::ObserverModel;
 
-  ObservedWorld Observe(const World& world) override {
-    PYBIND11_OVERLOAD_PURE(ObservedWorld, ObserverModel, Observe, world);
+  ObservedWorld Observe(
+    const WorldPtr& world, const AgentId& agent_id) override {
+    PYBIND11_OVERLOAD_PURE(
+      ObservedWorld, ObserverModel, Observe, world, agent_id);
   }
 
   std::shared_ptr<ObserverModel> Clone() const override {

--- a/bark/python_wrapper/models/observer.hpp
+++ b/bark/python_wrapper/models/observer.hpp
@@ -8,13 +8,15 @@
 
 #ifndef PYTHON_PYTHON_BINDINGS_MODELS_OBSERVER_HPP_
 #define PYTHON_PYTHON_BINDINGS_MODELS_OBSERVER_HPP_
-#include "bark/models/Observer/observer_model.hpp"
+#include "bark/models/observer/observer_model.hpp"
+#include "bark/models/observer/observer_model_none.hpp"
 #include "bark/python_wrapper/common.hpp"
+#include "bark/python_wrapper/polymorphic_conversion.hpp"
 
 namespace py = pybind11;
 using namespace bark::models::observer;
 using bark::world::AgentId;
-using bark::world::dWorldPtr;
+using bark::world::WorldPtr;
 
 class PyObserverModel : public ObserverModel {
  public:

--- a/bark/python_wrapper/models/observer.hpp
+++ b/bark/python_wrapper/models/observer.hpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 fortiss GmbH
+//
+// Authors: Julian Bernhard, Klemens Esterle, Patrick Hart and
+// Tobias Kessler
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#ifndef PYTHON_PYTHON_BINDINGS_MODELS_OBSERVER_HPP_
+#define PYTHON_PYTHON_BINDINGS_MODELS_OBSERVER_HPP_
+#include "bark/models/Observer/observer_model.hpp"
+#include "bark/python_wrapper/common.hpp"
+
+namespace py = pybind11;
+using namespace bark::models::observer;
+
+class PyObserverModel : public ObserverModel {
+ public:
+  using ObserverModel::ObserverModel;
+
+  ObservedWorld Observe(const World& world) override {
+    PYBIND11_OVERLOAD_PURE(ObservedWorld, ObserverModel, Observe, world);
+  }
+
+  std::shared_ptr<ObserverModel> Clone() const override {
+    PYBIND11_OVERLOAD_PURE(std::shared_ptr<ObserverModel>, ObserverModel,
+                           clone);
+  }
+};
+
+void python_observer(py::module m);
+
+#endif  // PYTHON_PYTHON_BINDINGS_MODELS_OBSERVER_HPP_

--- a/bark/python_wrapper/models/observer.hpp
+++ b/bark/python_wrapper/models/observer.hpp
@@ -27,11 +27,6 @@ class PyObserverModel : public ObserverModel {
     PYBIND11_OVERLOAD_PURE(
       ObservedWorld, ObserverModel, Observe, world, agent_id);
   }
-
-  std::shared_ptr<ObserverModel> Clone() const override {
-    PYBIND11_OVERLOAD_PURE(std::shared_ptr<ObserverModel>, ObserverModel,
-                           clone);
-  }
 };
 
 void python_observer(py::module m);

--- a/bark/python_wrapper/world/world.cpp
+++ b/bark/python_wrapper/world/world.cpp
@@ -59,6 +59,8 @@ void python_world(py::module m) {
       .def("GetAgent", &World::GetAgent)
       .def_property("map", &World::GetMap, &World::SetMap)
       .def("Copy", &World::Clone)
+      .def_property("observer_model", &World::GetObserverModel,
+                    &World::SetObserverModel)
       .def("GetWorldAtTime", &World::GetWorldAtTime)
       // .def("FillWorldFromCarla",&World::FillWorldFromCarla)
       // .def("PlanAgents",&World::PlanSpecificAgents)

--- a/bark/runtime/scenario/scenario.py
+++ b/bark/runtime/scenario/scenario.py
@@ -81,7 +81,7 @@ class Scenario:
     def copy(self):
         observer_model = None
         if self._observer_model is not None:
-          observer_model = self._observer_model.deepcopy()
+          observer_model = copy.deepcopy(self._observer_model)
         return Scenario(agent_list=copy.deepcopy(self._agent_list),
                         eval_agent_ids=self._eval_agent_ids.copy(),
                         map_file_name=self._map_file_name,

--- a/bark/runtime/scenario/scenario.py
+++ b/bark/runtime/scenario/scenario.py
@@ -84,7 +84,7 @@ class Scenario:
                         map_file_name=self._map_file_name,
                         json_params=self._json_params.copy(),
                         map_interface=self._map_interface,
-                        observer=self._observer_model.copy())
+                        observer=self._observer_model)
 
     def _build_world_state(self):
         param_server = ParameterServer(json=self._json_params)

--- a/bark/runtime/scenario/scenario.py
+++ b/bark/runtime/scenario/scenario.py
@@ -79,12 +79,15 @@ class Scenario:
         return self._build_world_state()
 
     def copy(self):
+        observer_model = None
+        if self._observer_model is not None:
+          observer_model = self._observer_model.deepcopy()
         return Scenario(agent_list=copy.deepcopy(self._agent_list),
                         eval_agent_ids=self._eval_agent_ids.copy(),
                         map_file_name=self._map_file_name,
                         json_params=self._json_params.copy(),
                         map_interface=self._map_interface,
-                        observer_model=self._observer_model)
+                        observer_model=observer_model)
 
     def _build_world_state(self):
         param_server = ParameterServer(json=self._json_params)

--- a/bark/runtime/scenario/scenario.py
+++ b/bark/runtime/scenario/scenario.py
@@ -84,7 +84,7 @@ class Scenario:
                         map_file_name=self._map_file_name,
                         json_params=self._json_params.copy(),
                         map_interface=self._map_interface,
-                        observer=self._observer_model)
+                        observer_model=self._observer_model)
 
     def _build_world_state(self):
         param_server = ParameterServer(json=self._json_params)

--- a/bark/runtime/scenario/scenario.py
+++ b/bark/runtime/scenario/scenario.py
@@ -35,12 +35,14 @@ class Scenario:
                  eval_agent_ids=None,
                  map_file_name=None,
                  json_params=None,
-                 map_interface=None):
+                 map_interface=None,
+                 observer_model=None):
         self._agent_list = agent_list or []
         self._eval_agent_ids = eval_agent_ids or []
         self._map_file_name = map_file_name
         self._json_params = json_params
         self._map_interface = map_interface
+        self._observer_model = observer_model
 
     @property
     def map_file_name(self):
@@ -81,11 +83,14 @@ class Scenario:
                         eval_agent_ids=self._eval_agent_ids.copy(),
                         map_file_name=self._map_file_name,
                         json_params=self._json_params.copy(),
-                        map_interface=self._map_interface)
+                        map_interface=self._map_interface,
+                        observer=self._observer_model.copy())
 
     def _build_world_state(self):
         param_server = ParameterServer(json=self._json_params)
         world = World(param_server)
+        if self._observer_model is not None:
+          world.SetObserverModel(self._observer_model)
         if self._map_interface is None:
             self.CreateMapInterface(self.full_map_file_name)
             world.SetMap(self._map_interface)

--- a/bark/runtime/scenario/scenario_generation/config_with_ease.py
+++ b/bark/runtime/scenario/scenario_generation/config_with_ease.py
@@ -222,10 +222,12 @@ class ConfigWithEase(ScenarioGeneration):
                map_file_name=None,
                params=None,
                random_seed=None,
-               lane_corridor_configs=None):
+               lane_corridor_configs=None,
+               observer_model=None):
     self._map_file_name = map_file_name
     self._lane_corridor_configs = lane_corridor_configs or []
     self._map_interface = None
+    self._observer_model = observer_model
     super(ConfigWithEase, self).__init__(params, num_scenarios)
     self.initialize_params(params)
 
@@ -245,7 +247,8 @@ class ConfigWithEase(ScenarioGeneration):
         Scenario -- Returns a BARK scenario
     """
     scenario = Scenario(map_file_name=self._map_file_name,
-                        json_params=self._params.ConvertToDict())
+                        json_params=self._params.ConvertToDict(),
+                        observer_model=self._observer_model)
     # as we always use the same world, we can create the MapIntf. once
     if self._map_interface is None:
       scenario.CreateMapInterface(self._map_file_name)

--- a/bark/world/BUILD
+++ b/bark/world/BUILD
@@ -13,6 +13,7 @@ cc_library(
         "//bark/models/execution:execution",
         "//bark/models/dynamic:dynamic",
         "//bark/models/observer:observer_model",
+        "//bark/models/observer:observer_model_none",
         "//bark/world/evaluation:base_evaluator",
         "//bark/world/goal_definition:goal_definition"
     ],
@@ -27,6 +28,7 @@ cc_library(
         "//bark/world/map:include",
         "//bark/world/opendrive:include",
         "//bark/commons/transformation:include",
+        "//bark/models/observer:include",
         "//bark/commons:include",
         "//bark/models:include",
         "//bark/world/evaluation:include",

--- a/bark/world/BUILD
+++ b/bark/world/BUILD
@@ -12,6 +12,7 @@ cc_library(
         "//bark/models/behavior:behavior",
         "//bark/models/execution:execution",
         "//bark/models/dynamic:dynamic",
+        "//bark/models/observer:observer_model",
         "//bark/world/evaluation:base_evaluator",
         "//bark/world/goal_definition:goal_definition"
     ],
@@ -25,6 +26,7 @@ cc_library(
         "//bark/geometry:include",
         "//bark/world/map:include",
         "//bark/world/opendrive:include",
+        "//bark/models/observer:observer_model",
         "//bark/commons/transformation:include",
         "//bark/commons:include",
         "//bark/models:include",

--- a/bark/world/BUILD
+++ b/bark/world/BUILD
@@ -26,7 +26,6 @@ cc_library(
         "//bark/geometry:include",
         "//bark/world/map:include",
         "//bark/world/opendrive:include",
-        "//bark/models/observer:observer_model",
         "//bark/commons/transformation:include",
         "//bark/commons:include",
         "//bark/models:include",

--- a/bark/world/observed_world.hpp
+++ b/bark/world/observed_world.hpp
@@ -35,6 +35,9 @@ using world::objects::Agent;
 using world::objects::AgentId;
 using world::objects::AgentPtr;
 
+// TODO: change to actual implementation
+// typedef UncertaintyInfo double;
+
 class ObservedWorld : public World {
  public:
   ObservedWorld(const WorldPtr& world, const AgentId& ego_agent_id)
@@ -147,6 +150,7 @@ class ObservedWorld : public World {
 
  private:
   AgentId ego_agent_id_;
+  // std::shared_ptr<UncertaintyInfo> uncertainty_info_;
 };
 
 typedef std::shared_ptr<ObservedWorld> ObservedWorldPtr;

--- a/bark/world/observed_world.hpp
+++ b/bark/world/observed_world.hpp
@@ -35,8 +35,9 @@ using world::objects::Agent;
 using world::objects::AgentId;
 using world::objects::AgentPtr;
 
-// TODO: change to actual implementation
-// typedef UncertaintyInfo double;
+// TODO: change to an actual implementation
+typedef double UncertaintyInfo;
+typedef std::shared_ptr<UncertaintyInfo> UncertaintyInfoPtr;
 
 class ObservedWorld : public World {
  public:
@@ -150,7 +151,7 @@ class ObservedWorld : public World {
 
  private:
   AgentId ego_agent_id_;
-  // std::shared_ptr<UncertaintyInfo> uncertainty_info_;
+  UncertaintyInfoPtr uncertainty_info_;
 };
 
 typedef std::shared_ptr<ObservedWorld> ObservedWorldPtr;

--- a/bark/world/world.cpp
+++ b/bark/world/world.cpp
@@ -12,6 +12,7 @@
 #include "bark/commons/util/segfault_handler.hpp"
 #include "bark/world/observed_world.hpp"
 #include "bark/world/world.hpp"
+#include "bark/models/observer/observer_model.hpp"
 
 namespace bark {
 namespace world {

--- a/bark/world/world.cpp
+++ b/bark/world/world.cpp
@@ -68,7 +68,7 @@ void World::PlanAgents(const double& delta_time) {
   const double inc_world_time = world_time_ + delta_time;
   for (auto agent : agents_) {
     if (agent.second->IsValidAtTime(world_time_)) {
-      ObservedWorld observed_world = obsever_->Observe(
+      ObservedWorld observed_world = observer_->Observe(
         current_world, agent.first);
       agent.second->PlanBehavior(delta_time, observed_world);
       if (agent.second->GetBehaviorStatus() == BehaviorStatus::VALID)
@@ -153,7 +153,7 @@ std::vector<ObservedWorld> World::Observe(
                  << std::endl;
       continue;
     }
-    ObservedWorld observed_world = obsever_->Observe(
+    ObservedWorld observed_world = observer_->Observe(
       current_world, agent_id);
     observed_worlds.push_back(observed_world);
   }

--- a/bark/world/world.cpp
+++ b/bark/world/world.cpp
@@ -63,6 +63,7 @@ void World::PlanAgents(const double& delta_time) {
   const double inc_world_time = world_time_ + delta_time;
   for (auto agent : agents_) {
     if (agent.second->IsValidAtTime(world_time_)) {
+      // TODO: here the observer model needs to be called
       ObservedWorld observed_world(current_world, agent.first);
       agent.second->PlanBehavior(delta_time, observed_world);
       if (agent.second->GetBehaviorStatus() == BehaviorStatus::VALID)

--- a/bark/world/world.cpp
+++ b/bark/world/world.cpp
@@ -12,19 +12,21 @@
 #include "bark/commons/util/segfault_handler.hpp"
 #include "bark/world/observed_world.hpp"
 #include "bark/world/world.hpp"
-#include "bark/models/observer/observer_model.hpp"
+#include "bark/models/observer/observer_model_none.hpp"
 
 namespace bark {
 namespace world {
 
 using models::behavior::BehaviorStatus;
 using models::execution::ExecutionStatus;
+using models::obsever::ObserverModelNone;
 
 World::World(const commons::ParamsPtr& params)
     : commons::BaseType(params),
       map_(),
       agents_(),
       world_time_(0.0),
+      observer_(ObserverModelNone(params)),
       remove_agents_(params->GetBool(
           "World::remove_agents_out_of_map",
           "Whether agents should be removed outside the bounding box.", false)),
@@ -45,6 +47,7 @@ World::World(const std::shared_ptr<World>& world)
       agents_(world->GetAgents()),
       objects_(world->GetObjects()),
       evaluators_(world->GetEvaluators()),
+      observer_(world->GetObserverModel()),
       world_time_(world->GetWorldTime()),
       remove_agents_(world->GetRemoveAgents()),
       frac_lateral_offset_(world->GetFracLateralOffset()),

--- a/bark/world/world.hpp
+++ b/bark/world/world.hpp
@@ -21,10 +21,14 @@
 #include "bark/world/map/roadgraph.hpp"
 #include "bark/world/objects/agent.hpp"
 #include "bark/world/objects/object.hpp"
-// #include "bark/models/observer/observer_model.hpp"
 #include "bark/world/opendrive/opendrive.hpp"
 
 namespace bark {
+namespace models {
+namespace observer {
+class ObserverModel;
+}
+}
 namespace world {
 
 using bark::commons::transformation::FrenetPosition;
@@ -36,7 +40,7 @@ using world::objects::Agent;
 using world::objects::AgentId;
 using world::objects::AgentPtr;
 using world::objects::ObjectPtr;
-// using bark::models::observer::ObserverModel;
+using bark::models::observer::ObserverModel;
 
 typedef std::map<AgentId, AgentPtr> AgentMap;
 typedef std::map<AgentId, ObjectPtr> ObjectMap;
@@ -189,7 +193,7 @@ class World : public commons::BaseType {
   AgentMap agents_;
   ObjectMap objects_;
   std::map<std::string, EvaluatorPtr> evaluators_;
-  // std::shared_ptr<ObserverModel> observer_;
+  std::shared_ptr<ObserverModel> observer_;
   double world_time_;
   AgentRTree rtree_agents_;
   bool remove_agents_;

--- a/bark/world/world.hpp
+++ b/bark/world/world.hpp
@@ -21,6 +21,7 @@
 #include "bark/world/map/roadgraph.hpp"
 #include "bark/world/objects/agent.hpp"
 #include "bark/world/objects/object.hpp"
+// #include "bark/models/observer/observer_model.hpp"
 #include "bark/world/opendrive/opendrive.hpp"
 
 namespace bark {
@@ -35,6 +36,7 @@ using world::objects::Agent;
 using world::objects::AgentId;
 using world::objects::AgentPtr;
 using world::objects::ObjectPtr;
+// using bark::models::observer::ObserverModel;
 
 typedef std::map<AgentId, AgentPtr> AgentMap;
 typedef std::map<AgentId, ObjectPtr> ObjectMap;
@@ -187,6 +189,7 @@ class World : public commons::BaseType {
   AgentMap agents_;
   ObjectMap objects_;
   std::map<std::string, EvaluatorPtr> evaluators_;
+  // std::shared_ptr<ObserverModel> observer_;
   double world_time_;
   AgentRTree rtree_agents_;
   bool remove_agents_;

--- a/bark/world/world.hpp
+++ b/bark/world/world.hpp
@@ -18,17 +18,13 @@
 #include <boost/geometry/index/rtree.hpp>
 #include "bark/commons/transformation/frenet.hpp"
 #include "bark/world/evaluation/base_evaluator.hpp"
+#include "bark/models/observer/observer_model.hpp"
 #include "bark/world/map/roadgraph.hpp"
 #include "bark/world/objects/agent.hpp"
 #include "bark/world/objects/object.hpp"
 #include "bark/world/opendrive/opendrive.hpp"
 
 namespace bark {
-namespace models {
-namespace observer {
-class ObserverModel;
-}
-}
 namespace world {
 
 using bark::commons::transformation::FrenetPosition;
@@ -40,7 +36,7 @@ using world::objects::Agent;
 using world::objects::AgentId;
 using world::objects::AgentPtr;
 using world::objects::ObjectPtr;
-using bark::models::observer::ObserverModel;
+using bark::models::observer::ObserverModelPtr;
 
 typedef std::map<AgentId, AgentPtr> AgentMap;
 typedef std::map<AgentId, ObjectPtr> ObjectMap;
@@ -131,7 +127,10 @@ class World : public commons::BaseType {
   std::map<std::string, EvaluatorPtr> GetEvaluators() const {
     return evaluators_;
   }
-
+  ObserverModelPtr GetObserverModel() const {
+    return observer_;
+  }
+  
   bool GetRemoveAgents() { return remove_agents_; }
 
   double GetFracLateralOffset() const { return frac_lateral_offset_; }
@@ -162,6 +161,9 @@ class World : public commons::BaseType {
 
   //! Setter
   void SetMap(const world::map::MapInterfacePtr& map) { map_ = map; }
+  void SetObserverModel(const ObserverModelPtr& observer) {
+    observer_ = observer;
+  }
 
   std::pair<bark::geometry::Point2d, bark::geometry::Point2d> BoundingBox()
       const {
@@ -193,7 +195,7 @@ class World : public commons::BaseType {
   AgentMap agents_;
   ObjectMap objects_;
   std::map<std::string, EvaluatorPtr> evaluators_;
-  std::shared_ptr<ObserverModel> observer_;
+  ObserverModelPtr observer_;
   double world_time_;
   AgentRTree rtree_agents_;
   bool remove_agents_;


### PR DESCRIPTION
This draft PR shall serve as discussion basis for ObserverModel related implementations.

----

The `ObserverModel` is now used in the world and world-Step(..) function to generate ObservedWorlds for each Agent.
The `ObserverModelNone` implements the basic functionality that should not differ from the current behavior in BARK right now.

