### PR TITLE
Junction area as part of the road corridor

### DIFF
--- a/bark/geometry/polygon.hpp
+++ b/bark/geometry/polygon.hpp
@@ -54,6 +54,10 @@ struct Polygon_t : public Shape<bg::model::polygon<T>, T> {
     }
   }
 
+  void ClearInners() {
+    this->obj_.inners().clear();
+  }
+
   void SetPrecision(int precision) {
     const double scale = pow(10, precision);
     for (auto it = this->obj_.outer().begin(); it != this->obj_.outer().end();

--- a/bark/python_wrapper/world/map.cpp
+++ b/bark/python_wrapper/world/map.cpp
@@ -26,6 +26,9 @@ using bark::world::opendrive::XodrLaneId;
 void python_map(py::module m) {
   py::class_<MapInterface, std::shared_ptr<MapInterface>>(m, "MapInterface")
       .def(py::init<>())
+      .def_property("add_full_junction_area",
+                    &MapInterface::GetAddFullJunctionArea,
+                    &MapInterface::SetAddFullJunctionArea)
       .def("SetOpenDriveMap", &MapInterface::SetOpenDriveMap)
       .def("find_nearest_lanes",
            [](const MapInterface& m, const Point2d& point,
@@ -114,7 +117,8 @@ void python_map(py::module m) {
       .def(py::init<>())
       .def_property_readonly("polygon", &LaneCorridor::GetMergedPolygon)
       .def_property_readonly("center_line", &LaneCorridor::GetCenterLine)
-      .def_property_readonly("fine_center_line", &LaneCorridor::GetFineCenterLine)
+      .def_property_readonly("fine_center_line",
+                             &LaneCorridor::GetFineCenterLine)
       .def_property_readonly("left_boundary", &LaneCorridor::GetLeftBoundary)
       .def_property_readonly("right_boundary", &LaneCorridor::GetRightBoundary)
       .def_property_readonly("lanes", &LaneCorridor::GetLanes)

--- a/bark/python_wrapper/world/map.cpp
+++ b/bark/python_wrapper/world/map.cpp
@@ -48,7 +48,8 @@ void python_map(py::module m) {
       .def("GetRoadCorridor", &MapInterface::GetRoadCorridor)
       .def("GetLane", &MapInterface::GetLane)
       .def("ComputeAllPathBoundaries", &MapInterface::ComputeAllPathBoundaries)
-      .def("FindLane", &MapInterface::FindXodrLane);
+      .def("FindLane", &MapInterface::FindXodrLane)
+      .def("ComputeJunctionArea", &MapInterface::ComputeJunctionArea);
 
   py::class_<Roadgraph, std::shared_ptr<Roadgraph>>(m, "Roadgraph")
       .def(py::init<>())

--- a/bark/python_wrapper/world/map.cpp
+++ b/bark/python_wrapper/world/map.cpp
@@ -26,9 +26,9 @@ using bark::world::opendrive::XodrLaneId;
 void python_map(py::module m) {
   py::class_<MapInterface, std::shared_ptr<MapInterface>>(m, "MapInterface")
       .def(py::init<>())
-      .def_property("add_full_junction_area",
-                    &MapInterface::GetAddFullJunctionArea,
-                    &MapInterface::SetAddFullJunctionArea)
+      .def_property("full_junction_area",
+                    &MapInterface::GetFullJunctionArea,
+                    &MapInterface::SetFullJunctionArea)
       .def("SetOpenDriveMap", &MapInterface::SetOpenDriveMap)
       .def("find_nearest_lanes",
            [](const MapInterface& m, const Point2d& point,

--- a/bark/python_wrapper/world/opendrive.cpp
+++ b/bark/python_wrapper/world/opendrive.cpp
@@ -89,6 +89,10 @@ void python_opendrive(py::module m) {
       .def(py::init<>())
       .def(py::init<XodrLanePosition&>())
       .def_property("lane_id", &XodrLane::GetId, &XodrLane::SetId)
+      .def_property("junction_id", &XodrLane::GetJunctionId,
+                    &XodrLane::SetJunctionId)
+      .def_property("is_in_junction", &XodrLane::GetIsInJunction,
+                    &XodrLane::SetIsInJunction)
       .def_property("lane_position", &XodrLane::GetLanePosition,
                     &XodrLane::SetLanePosition)
       .def_property("lane_type", &XodrLane::GetLaneType, &XodrLane::SetLaneType)

--- a/bark/runtime/tests/py_importer_tests.py
+++ b/bark/runtime/tests/py_importer_tests.py
@@ -61,6 +61,13 @@ class ImporterTests(unittest.TestCase):
     map_interface.SetOpenDriveMap(xodr_parser.map)
     # helper_plot(xodr_parser)
 
+  def test_map_4way_intersection(self):
+    xodr_parser = XodrParser(os.path.join(os.path.dirname(__file__),"data/4way_intersection.xodr"))
+
+    map_interface = MapInterface()
+    map_interface.SetOpenDriveMap(xodr_parser.map)
+    # helper_plot(xodr_parser)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/bark/runtime/tests/py_importer_tests.py
+++ b/bark/runtime/tests/py_importer_tests.py
@@ -9,68 +9,72 @@
 import unittest
 import os
 import matplotlib.pyplot as plt
-from bark.core.geometry.standard_shapes import *
 from bark.core.world.opendrive import XodrLaneType
 from bark.core.world.map import MapInterface
 from bark.runtime.commons.xodr_parser import XodrParser
 
 
 def helper_plot(xodr_parser):
-  for _, road in xodr_parser.map.GetRoads().items():
-    for lane_section in road.lane_sections:
-      for _, lane in lane_section.GetLanes().items():
-        if lane.lane_type == XodrLaneType.driving:
-          color = "grey"
-        elif lane.lane_type == XodrLaneType.sidewalk:
-          color = "green"
-        elif lane.lane_type == XodrLaneType.border:
-          color = "red"
-        elif lane.lane_type == XodrLaneType.none:
-          color = "blue"
-        else:
-          continue
-        line_np = lane.line.ToArray()
+    for _, road in xodr_parser.map.GetRoads().items():
+        for lane_section in road.lane_sections:
+            for _, lane in lane_section.GetLanes().items():
+                if lane.lane_type == XodrLaneType.driving:
+                    color = "grey"
+                elif lane.lane_type == XodrLaneType.sidewalk:
+                    color = "green"
+                elif lane.lane_type == XodrLaneType.border:
+                    color = "red"
+                elif lane.lane_type == XodrLaneType.none:
+                    color = "blue"
+                else:
+                    continue
+                line_np = lane.line.ToArray()
 
-        # print(lane.road_mark)
-        plt.text(line_np[-1, 0], line_np[-1, 1],
-                 'outer_{i}_{j}'.format(i=lane.lane_id, j=lane.lane_position))
+                # print(lane.road_mark)
+                plt.text(line_np[-1, 0], line_np[-1, 1],
+                         'outer_{i}_{j}'.format(i=lane.lane_id, j=lane.lane_position))
 
-        plt.plot(
-            line_np[:, 0],
-            line_np[:, 1],
-            color=color,
-            alpha=1.0)
+                plt.plot(
+                    line_np[:, 0],
+                    line_np[:, 1],
+                    color=color,
+                    alpha=1.0)
 
-  plt.axis("equal")
-  plt.show()
+    plt.axis("equal")
+    plt.show()
 
 
 class ImporterTests(unittest.TestCase):
-  def test_map_highway(self):
-    xodr_parser = XodrParser(os.path.join(os.path.dirname(__file__),"data/city_highway_straight.xodr"))
+    def test_map_highway(self):
+        xodr_parser = XodrParser(os.path.join(os.path.dirname(
+            __file__), "data/city_highway_straight.xodr"))
 
-    map_interface = MapInterface()
-    map_interface.SetOpenDriveMap(xodr_parser.map)
-    # helper_plot(xodr_parser)
+        map_interface = MapInterface()
+        map_interface.SetOpenDriveMap(xodr_parser.map)
+        # helper_plot(xodr_parser)
 
+        self.assertTrue(map_interface)
 
-  def test_map_DR_DEU_Merging_MT_v01_shifted(self):
-    xodr_parser = XodrParser(os.path.join(os.path.dirname(__file__),"data/DR_DEU_Merging_MT_v01_shifted.xodr"))
+    def test_map_DR_DEU_Merging_MT_v01_shifted(self):
+        xodr_parser = XodrParser(os.path.join(os.path.dirname(
+            __file__), "data/DR_DEU_Merging_MT_v01_shifted.xodr"))
 
-    map_interface = MapInterface()
-    map_interface.SetOpenDriveMap(xodr_parser.map)
-    # helper_plot(xodr_parser)
+        map_interface = MapInterface()
+        map_interface.SetOpenDriveMap(xodr_parser.map)
+        # helper_plot(xodr_parser)
 
-  def test_map_4way_intersection(self):
-    xodr_parser = XodrParser(os.path.join(os.path.dirname(__file__),"data/4way_intersection.xodr"))
+        self.assertTrue(map_interface)
 
-    map_interface = MapInterface()
-    map_interface.SetOpenDriveMap(xodr_parser.map)
-    # helper_plot(xodr_parser)
+    def test_map_4way_intersection(self):
+        xodr_parser = XodrParser(os.path.join(
+            os.path.dirname(__file__), "data/4way_intersection.xodr"))
 
-    self.assertTrue(map_interface)
-    
+        map_interface = MapInterface()
+        map_interface.SetOpenDriveMap(xodr_parser.map)
+        # helper_plot(xodr_parser)
+
+        self.assertTrue(map_interface)
 
 
 if __name__ == '__main__':
-  unittest.main()
+    unittest.main()

--- a/bark/runtime/tests/py_importer_tests.py
+++ b/bark/runtime/tests/py_importer_tests.py
@@ -68,6 +68,9 @@ class ImporterTests(unittest.TestCase):
     map_interface.SetOpenDriveMap(xodr_parser.map)
     # helper_plot(xodr_parser)
 
+    self.assertTrue(map_interface)
+    
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/bark/world/map/map_interface.cpp
+++ b/bark/world/map/map_interface.cpp
@@ -67,8 +67,8 @@ bool MapInterface::FindNearestXodrLanes(const Point2d& point,
 XodrLanePtr MapInterface::FindXodrLane(const Point2d& point) const {
   XodrLanePtr lane;
   std::vector<XodrLanePtr> nearest_lanes;
-  // TODO(@esterle): parameter (20) auslagern
-  if (!FindNearestXodrLanes(point, 20, nearest_lanes, false)) {
+  if (!FindNearestXodrLanes(point, num_points_nearest_lane_, nearest_lanes,
+                            false)) {
     return nullptr;
   }
   for (auto& close_lane : nearest_lanes) {
@@ -199,24 +199,26 @@ void MapInterface::CalculateLaneCorridors(RoadCorridorPtr& road_corridor,
       road_corridor->SetLaneCorridor(next_lane->GetId(), lane_corridor);
     }
 
-    // TODO(@hart): use parameter
-    // \note \kessler: setting max_dist too small can yield self-intersecting
-    // road polygons. why? in curves on the inner radius due to sampling
-    // inaccuracy the boundaries of two segments can overlap. The code below
-    // just copies each point to the lane polygon without checking this.
+    // \note \kessler: setting max_simplification_dist_ too small can yield
+    // self-intersecting road polygons. why? in curves on the inner radius due
+    // to sampling inaccuracy the boundaries of two segments can overlap. The
+    // code below just copies each point to the lane polygon without checking
+    // this.
 
-    const double max_dist = 0.4;
-    Line simplf_center = Simplify(lane_corridor->GetCenterLine(), max_dist);
+    Line simplf_center =
+        Simplify(lane_corridor->GetCenterLine(), max_simplification_dist_);
     lane_corridor->SetCenterLine(simplf_center);
 
     Line simplf_fine_center =
         Simplify(lane_corridor->GetFineCenterLine(), 0.001);
     lane_corridor->SetFineCenterLine(simplf_fine_center);
 
-    Line simplf_right = Simplify(lane_corridor->GetRightBoundary(), max_dist);
+    Line simplf_right =
+        Simplify(lane_corridor->GetRightBoundary(), max_simplification_dist_);
     lane_corridor->SetRightBoundary(simplf_right);
 
-    Line simplf_left = Simplify(lane_corridor->GetLeftBoundary(), max_dist);
+    Line simplf_left =
+        Simplify(lane_corridor->GetLeftBoundary(), max_simplification_dist_);
     lane_corridor->SetLeftBoundary(simplf_left);
 
     // TODO hier ist der self intersection bug: magic number 0.5 durch sampling
@@ -287,7 +289,6 @@ RoadPtr MapInterface::GenerateRoadCorridorRoad(const XodrRoadId& road_id) {
 void MapInterface::GenerateRoadCorridor(
     const std::vector<XodrRoadId>& road_ids,
     const XodrDrivingDirection& driving_direction) {
-  bool add_full_juction = true;  //!todo @tobias Parameter
   std::size_t road_corridor_hash =
       RoadCorridor::GetHash(driving_direction, road_ids);
 
@@ -378,7 +379,7 @@ void MapInterface::GenerateRoadCorridor(
   road_corridor->SetRoads(roads);
   CalculateLaneCorridors(road_corridor, road_ids[0]);
   road_corridor->ComputeRoadPolygon();
-  if (add_full_juction) {
+  if (add_full_junction_area_) {
     for (auto& junction : road_corridor->GetJunctionIds()) {
       const Polygon poly = ComputeJunctionArea(junction);
       road_corridor->AddPolygonToRoadCorridor(std::move(poly));
@@ -458,7 +459,7 @@ RoadPtr MapInterface::GetNextRoad(
 
 bark::geometry::Polygon MapInterface::ComputeJunctionArea(
     uint32_t junction_id) {
-  PolygonPtr poly = roadgraph_->ComputeJunctionArea(junction_id); 
+  PolygonPtr poly = roadgraph_->ComputeJunctionArea(junction_id);
   return *poly.get();
 }
 

--- a/bark/world/map/map_interface.cpp
+++ b/bark/world/map/map_interface.cpp
@@ -379,7 +379,7 @@ void MapInterface::GenerateRoadCorridor(
   road_corridor->SetRoads(roads);
   CalculateLaneCorridors(road_corridor, road_ids[0]);
   road_corridor->ComputeRoadPolygon();
-  if (add_full_junction_area_) {
+  if (full_junction_area_) {
     for (auto& junction : road_corridor->GetJunctionIds()) {
       const Polygon poly = ComputeJunctionArea(junction);
       road_corridor->AddPolygonToRoadCorridor(std::move(poly));

--- a/bark/world/map/map_interface.hpp
+++ b/bark/world/map/map_interface.hpp
@@ -42,7 +42,7 @@ class MapInterface {
   MapInterface()
       : num_points_nearest_lane_(20),
         max_simplification_dist_(0.4),
-        add_full_junction_area_(false) {}
+        full_junction_area_(false) {}
 
   bool interface_from_opendrive(const OpenDriveMapPtr& open_drive_map);
 
@@ -116,8 +116,8 @@ class MapInterface {
     return road_id;
   }
   bark::geometry::Polygon ComputeJunctionArea(uint32_t junction_id);
-  void SetAddFullJunctionArea(bool in) { add_full_junction_area_ = in; }
-  bool GetAddFullJunctionArea() { return add_full_junction_area_; }
+  void SetFullJunctionArea(bool in) { full_junction_area_ = in; }
+  bool GetFullJunctionArea() { return full_junction_area_; }
 
  private:
   OpenDriveMapPtr open_drive_map_;
@@ -129,7 +129,7 @@ class MapInterface {
   // Parameters
   unsigned num_points_nearest_lane_;
   double max_simplification_dist_;
-  bool add_full_junction_area_;
+  bool full_junction_area_;
 
   static bool IsLaneType(rtree_lane_value const& m) {
     return (m.second->GetLaneType() == XodrLaneType::DRIVING);

--- a/bark/world/map/map_interface.hpp
+++ b/bark/world/map/map_interface.hpp
@@ -111,6 +111,7 @@ class MapInterface {
     XodrRoadId road_id = roadgraph_->GetRoadForLaneId(FindCurrentLane(pt));
     return road_id;
   }
+  bark::geometry::Polygon ComputeJunctionArea(uint32_t junction_id);
 
  private:
   OpenDriveMapPtr open_drive_map_;

--- a/bark/world/map/map_interface.hpp
+++ b/bark/world/map/map_interface.hpp
@@ -39,6 +39,11 @@ using PathBoundaries = std::vector<std::pair<XodrLanePtr, XodrLanePtr>>;
 
 class MapInterface {
  public:
+  MapInterface()
+      : num_points_nearest_lane_(20),
+        max_simplification_dist_(0.4),
+        add_full_junction_area_(false) {}
+
   bool interface_from_opendrive(const OpenDriveMapPtr& open_drive_map);
 
   bool FindNearestXodrLanes(const Point2d& point, const unsigned& num_lanes,
@@ -103,7 +108,6 @@ class MapInterface {
     if (road_corridors_.count(rc_hash) == 0) return nullptr;
     return road_corridors_.at(rc_hash);
   }
-
   LaneId FindCurrentLane(const Point2d& pt) {
     return FindXodrLane(pt)->GetId();
   }
@@ -112,6 +116,8 @@ class MapInterface {
     return road_id;
   }
   bark::geometry::Polygon ComputeJunctionArea(uint32_t junction_id);
+  void SetAddFullJunctionArea(bool in) { add_full_junction_area_ = in; }
+  bool GetAddFullJunctionArea() { return add_full_junction_area_; }
 
  private:
   OpenDriveMapPtr open_drive_map_;
@@ -119,6 +125,11 @@ class MapInterface {
   rtree_lane rtree_lane_;
   std::pair<Point2d, Point2d> bounding_box_;
   std::map<std::size_t, RoadCorridorPtr> road_corridors_;
+
+  // Parameters
+  unsigned num_points_nearest_lane_;
+  double max_simplification_dist_;
+  bool add_full_junction_area_;
 
   static bool IsLaneType(rtree_lane_value const& m) {
     return (m.second->GetLaneType() == XodrLaneType::DRIVING);

--- a/bark/world/map/road_corridor.hpp
+++ b/bark/world/map/road_corridor.hpp
@@ -121,6 +121,23 @@ struct RoadCorridor {
   void SetRoadIds(const std::vector<XodrRoadId>& road_ids) {
     road_ids_ = road_ids;
   }
+  void AddPolygonToRoadCorridor(const Polygon& input, double buffer_dist = 0.3) {
+    Polygon buffered_input;
+    BufferPolygon(input, -buffer_dist, &buffered_input);
+    road_polygon_.ConcatenatePolygons(buffered_input);
+  }
+  std::vector<uint32_t> GetJunctionIds() {
+    std::vector<uint32_t> junctions;
+    for (const auto& lane_corr : unique_lane_corridors_) {
+      const auto& lanes = lane_corr->GetLanes();
+      for (const auto& lane : lanes) {
+        if (lane.second->GetIsInJunction()) {
+          junctions.push_back(lane.second->GetJunctionId());
+        }
+      }
+    }
+    return junctions;
+  }
 
   Roads roads_;
   Polygon road_polygon_;

--- a/bark/world/map/road_corridor.hpp
+++ b/bark/world/map/road_corridor.hpp
@@ -121,10 +121,8 @@ struct RoadCorridor {
   void SetRoadIds(const std::vector<XodrRoadId>& road_ids) {
     road_ids_ = road_ids;
   }
-  void AddPolygonToRoadCorridor(const Polygon& input, double buffer_dist = 0.3) {
-    Polygon buffered_input;
-    BufferPolygon(input, -buffer_dist, &buffered_input);
-    road_polygon_.ConcatenatePolygons(buffered_input);
+  void AddPolygonToRoadCorridor(const Polygon& input) {
+    road_polygon_.ConcatenatePolygons(input);
   }
   std::vector<uint32_t> GetJunctionIds() {
     std::vector<uint32_t> junctions;

--- a/bark/world/map/road_corridor.hpp
+++ b/bark/world/map/road_corridor.hpp
@@ -121,8 +121,19 @@ struct RoadCorridor {
   void SetRoadIds(const std::vector<XodrRoadId>& road_ids) {
     road_ids_ = road_ids;
   }
-  void AddPolygonToRoadCorridor(const Polygon& input) {
-    road_polygon_.ConcatenatePolygons(input);
+  void AddPolygonToRoadCorridor(const Polygon& input, double buffer_dist = 0.1) {
+    //inflate both polygons to be merged first to avoid small holes later
+    Polygon buffered_input;
+    BufferPolygon(input, buffer_dist, &buffered_input);
+    Polygon road_polygon_buffered;
+    BufferPolygon(road_polygon_, buffer_dist, &road_polygon_buffered);
+
+    road_polygon_buffered.ConcatenatePolygons(buffered_input);
+
+    // deflate again and assign road_polygon_
+    Polygon new_road_polygon;
+    BufferPolygon(road_polygon_buffered, -buffer_dist, &new_road_polygon);
+    road_polygon_ = new_road_polygon;
   }
   std::vector<uint32_t> GetJunctionIds() {
     std::vector<uint32_t> junctions;

--- a/bark/world/map/roadgraph.cpp
+++ b/bark/world/map/roadgraph.cpp
@@ -812,9 +812,10 @@ PolygonPtr Roadgraph::ComputeJunctionArea(uint32_t junction_id) {
   std::vector<vertex_t> vertices = GetVertices();
   for (auto const& v : vertices) {
     const auto& lane = g_[v].lane;
-    if (lane->GetIsInJunction() && (lane->GetJunctionId() == junction_id)) {
+    if (lane->GetIsInJunction() && (lane->GetJunctionId() == junction_id) &&
+        lane->GetLaneType() == XodrLaneType::DRIVING) {
       PolygonPtr this_poly = g_[v].polygon;
-      if(this_poly) {
+      if (this_poly) {
         polygon->ConcatenatePolygons(*this_poly.get());
       }
     }

--- a/bark/world/map/roadgraph.cpp
+++ b/bark/world/map/roadgraph.cpp
@@ -807,6 +807,22 @@ std::pair<XodrLaneId, bool> Roadgraph::GetRightBoundary(
   return std::make_pair(0, false);
 }
 
+PolygonPtr Roadgraph::ComputeJunctionArea(uint32_t junction_id) {
+  PolygonPtr polygon = std::make_shared<bark::geometry::Polygon>();
+  std::vector<vertex_t> vertices = GetVertices();
+  for (auto const& v : vertices) {
+    const auto& lane = g_[v].lane;
+    if (lane->GetIsInJunction() && (lane->GetJunctionId() == junction_id)) {
+      PolygonPtr this_poly = g_[v].polygon;
+      if(this_poly) {
+        polygon->ConcatenatePolygons(*this_poly.get());
+      }
+    }
+  }
+  polygon->ClearInners();
+  return polygon;
+}
+
 }  // namespace map
 }  // namespace world
 }  // namespace bark

--- a/bark/world/map/roadgraph.hpp
+++ b/bark/world/map/roadgraph.hpp
@@ -251,6 +251,7 @@ class Roadgraph {
       const XodrLaneId& lane_id, const XodrDrivingDirection& driving_direction);
   std::pair<XodrLaneId, bool> GetRightBoundary(
       const XodrLaneId& lane_id, const XodrDrivingDirection& driving_direction);
+  PolygonPtr ComputeJunctionArea(uint32_t junction_id);
 
  private:
   XodrLaneGraph g_;

--- a/bark/world/opendrive/lane.cpp
+++ b/bark/world/opendrive/lane.cpp
@@ -22,7 +22,9 @@ XodrLane::XodrLane()
       lane_type_(XodrLaneType::NONE),
       driving_direction_(XodrDrivingDirection::FORWARD),
       road_mark_(),
-      speed_() {}
+      speed_(),
+      junction_id_(),
+      is_in_junction_(false) {}
 
 XodrLane::XodrLane(const XodrLanePosition& lane_position)
     : lane_id_(++lane_count),
@@ -32,7 +34,9 @@ XodrLane::XodrLane(const XodrLanePosition& lane_position)
       lane_type_(XodrLaneType::NONE),
       driving_direction_(XodrDrivingDirection::FORWARD),
       road_mark_(),
-      speed_() {}
+      speed_(),
+      junction_id_(),
+      is_in_junction_(false) {}
 
 bool XodrLane::append(geometry::Line previous_line,
                       XodrLaneWidth lane_width_current, double s_inc) {

--- a/bark/world/opendrive/lane.hpp
+++ b/bark/world/opendrive/lane.hpp
@@ -36,7 +36,9 @@ class XodrLane {
         lane_type_(lane->lane_type_),
         driving_direction_(lane->driving_direction_),
         road_mark_(lane->road_mark_),
-        speed_(lane->speed_) {}
+        speed_(lane->speed_),
+        junction_id_(lane->junction_id_),
+        is_in_junction_(lane->is_in_junction_) {}
 
   ~XodrLane() {}
 
@@ -53,6 +55,8 @@ class XodrLane {
   void SetLanePosition(const XodrLanePosition& lane_position) {
     lane_position_ = lane_position;
   }
+  void SetJunctionId(const uint32_t id) { junction_id_ = id; }
+  void SetIsInJunction(const bool in) { is_in_junction_ = in; }
 
   bool append(Line previous_line, XodrLaneWidth lane_width_current,
               double s_inc);
@@ -69,13 +73,16 @@ class XodrLane {
   }
   XodrLaneId GetId() const { return lane_id_; }
   XodrLanePosition GetLanePosition() const { return lane_position_; }
+  uint32_t GetJunctionId() { return junction_id_; }
+  bool GetIsInJunction() { return is_in_junction_; }
 
  private:
   XodrLaneId lane_id_;
   XodrLanePosition lane_position_;
   XodrLaneLink link_;
   Line line_;
-
+  uint32_t junction_id_; //id of a junction this lane belongs to
+  bool is_in_junction_;
   XodrLaneType lane_type_;
   XodrDrivingDirection driving_direction_;
   XodrRoadMark road_mark_;

--- a/bark/world/tests/map/py_map_interface_tests.py
+++ b/bark/world/tests/map/py_map_interface_tests.py
@@ -142,6 +142,7 @@ class EnvironmentTests(unittest.TestCase):
         params = ParameterServer()
         world = World(params)
         map_interface = MapInterface()
+        map_interface.add_full_junction_area = True
         map_interface.SetOpenDriveMap(xodr_parser.map)
         world.SetMap(map_interface)
 

--- a/bark/world/tests/map/py_map_interface_tests.py
+++ b/bark/world/tests/map/py_map_interface_tests.py
@@ -111,6 +111,52 @@ class EnvironmentTests(unittest.TestCase):
         self.assertTrue(
             switched_lane, "Eventually should have switched lanes!")
 
+    def test_junction_area(self):
+      xodr_parser = XodrParser(os.path.join(os.path.dirname(
+              __file__), "../../../runtime/tests/data/4way_intersection.xodr"))
+      np.set_printoptions(precision=8)
+      params = ParameterServer()
+      world = World(params)
+      map_interface = MapInterface()
+      map_interface.SetOpenDriveMap(xodr_parser.map)
+      world.SetMap(map_interface)
+
+      poly = map_interface.ComputeJunctionArea(4)
+      
+      #print(poly)
+      #viewer = MPViewer(params=params, use_world_bounds=True)
+      #viewer.drawWorld(world)
+      #viewer.drawPolygon(poly)
+      #viewer.show(block=True)
+
+      area = poly.CalculateArea()
+      self.assertTrue(abs(area - 235.21) < 0.1)
+
+    def test_extended_road_corridor_with_junction_area(self):
+        params = ParameterServer()
+        world = World(params)
+
+        xodr_parser = XodrParser(os.path.join(os.path.dirname(
+              __file__), "../../../runtime/tests/data/4way_intersection.xodr"))
+        np.set_printoptions(precision=8)
+        params = ParameterServer()
+        world = World(params)
+        map_interface = MapInterface()
+        map_interface.SetOpenDriveMap(xodr_parser.map)
+        world.SetMap(map_interface)
+
+        roads = [2, 6, 1]
+        driving_direction = XodrDrivingDirection.forward
+        map_interface.GenerateRoadCorridor(roads, driving_direction)
+        road_corr = map_interface.GetRoadCorridor(roads, driving_direction)
+
+        viewer = MPViewer(params=params, use_world_bounds=True)
+        viewer.drawWorld(world)
+        viewer.drawRoadCorridor(road_corr)
+        # viewer.show(block=True)
+
+        # if this is not here, the second unit test is not executed (maybe parsing takes too long?)
+        time.sleep(1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/bark/world/tests/map/py_map_interface_tests.py
+++ b/bark/world/tests/map/py_map_interface_tests.py
@@ -159,5 +159,7 @@ class EnvironmentTests(unittest.TestCase):
         # if this is not here, the second unit test is not executed (maybe parsing takes too long?)
         time.sleep(1)
 
+        self.assertTrue(road_corr)
+
 if __name__ == '__main__':
     unittest.main()

--- a/bark/world/tests/map/py_map_interface_tests.py
+++ b/bark/world/tests/map/py_map_interface_tests.py
@@ -130,7 +130,7 @@ class EnvironmentTests(unittest.TestCase):
       #viewer.show(block=True)
 
       area = poly.CalculateArea()
-      self.assertTrue(abs(area - 235.21) < 0.1)
+      self.assertTrue(abs(area - 228.41) < 0.1)
 
     def test_extended_road_corridor_with_junction_area(self):
         params = ParameterServer()
@@ -142,7 +142,7 @@ class EnvironmentTests(unittest.TestCase):
         params = ParameterServer()
         world = World(params)
         map_interface = MapInterface()
-        map_interface.add_full_junction_area = True
+        map_interface.full_junction_area = True
         map_interface.SetOpenDriveMap(xodr_parser.map)
         world.SetMap(map_interface)
 


### PR DESCRIPTION
On junctions, the road corridor was rather a lane corridor. This in intersection scenarios somehow predefined the interaction of vehicles as the set of actions in the intersection was very limited.

I now added ALL lanes inside a junction to a junction area that is used for the road corridor, if it passes the junction, see screenshot.

Default behavior is UNCHANGED, shouldnt break anything. Activate in the map interface via:
`map_interface = MapInterface()
map_interface.full_junction_area = True
map_interface.SetOpenDriveMap(xodr_parser.map)`
see also py_map_interface_test

![Screenshot from 2021-09-30 09-12-11](https://user-images.githubusercontent.com/49236400/135419070-ae908c7c-a03b-49d1-b18b-e49ba8439690.png)
